### PR TITLE
Enable EA Upgrade Testing in CI, Fresh Installs in Production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/*
+**/__pycache__/
 utils/operator-processor/*.yaml
 utils/operator-processor/*.json
 utils/release-helper/release-*/**

--- a/utils/fbc-processor/fbc-processor.py
+++ b/utils/fbc-processor/fbc-processor.py
@@ -10,6 +10,9 @@ import base64
 import sys
 class fbc_processor:
     PRODUCTION_REGISTRY = 'registry.redhat.io'
+    # Channel names that are reset from patch (no merge with base catalog).
+    RESET_CHANNELS = {'alpha'}
+
     def __init__(self, build_config_path:str, catalog_yaml_path:str, patch_yaml_path:str, single_bundle_path:str, output_file_path:str, push_pipeline_operation:str, push_pipeline_yaml_path:str):
         self.build_config_path = build_config_path
         self.catalog_yaml_path = catalog_yaml_path
@@ -93,10 +96,12 @@ class fbc_processor:
         SCHEMA = 'olm.channel'
         PATCH_SCHEMA = 'olm.channels'
         for channel in self.patch_dict['patch'][PATCH_SCHEMA]:
-            if channel['name'] in self.catalog_dict[SCHEMA]:
+            if channel['name'] in self.catalog_dict[SCHEMA] and channel['name'] not in self.RESET_CHANNELS:
                 self.catalog_dict[SCHEMA][channel['name']] = jsonupdate_ng.updateJson(self.catalog_dict[SCHEMA][channel['name']], channel, meta={'listPatchScheme': {'$.entries': {'key': 'name'}}})
             else:
+                # If reset channel or new channel, take full definition from patch.
                 self.catalog_dict[SCHEMA][channel['name']] = channel
+
 
     def apply_replacements_to_catalog(self, olm_bundle):
         olm_bundle['image'] = self.apply_replacement(olm_bundle['image'])

--- a/utils/fbc-processor/fbc-processor.py
+++ b/utils/fbc-processor/fbc-processor.py
@@ -11,7 +11,7 @@ import sys
 class fbc_processor:
     PRODUCTION_REGISTRY = 'registry.redhat.io'
     # Channel names that are reset from patch (no merge with base catalog).
-    RESET_CHANNELS = {'alpha'}
+    RESET_CHANNELS = {'beta'}
 
     def __init__(self, build_config_path:str, catalog_yaml_path:str, patch_yaml_path:str, single_bundle_path:str, output_file_path:str, push_pipeline_operation:str, push_pipeline_yaml_path:str):
         self.build_config_path = build_config_path

--- a/utils/stage-promoter/stage_promoter.py
+++ b/utils/stage-promoter/stage_promoter.py
@@ -1,4 +1,6 @@
-import os, requests
+import os
+import re
+import requests
 import time
 import openshift_client as oc
 from jsonupdate_ng import jsonupdate_ng
@@ -13,9 +15,14 @@ from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 import base64
 import sys
 
+
 class stage_promoter:
     PRODUCTION_REGISTRY = 'registry.redhat.io'
     PACKAGE_NAME = 'rhods-operator'
+    # Channel names that are reset from patch (no merge with base catalog).
+    RESET_CHANNELS = {'alpha'}
+    # Version after PACKAGE_NAME.: X.Y.Z-ea.N or X.Y.Z-ea.N.H (H optional). X=0-9, Y/Z=0-99.
+    EA_VERSION_PATTERN = re.compile(r"^[0-9]\.[0-9]{1,2}\.[0-9]{1,2}-ea\.[0-9]+(\.[0-9]+)?$")
 
     def __init__(self, catalog_yaml_path:str, patch_yaml_path:str, release_catalog_yaml_path:str, output_file_path:str, rhoai_version:str):
         self.catalog_yaml_path = catalog_yaml_path
@@ -89,14 +96,84 @@ class stage_promoter:
         SCHEMA = 'olm.channel'
         PATCH_SCHEMA = 'olm.channels'
         for channel in self.patch_dict['patch'][PATCH_SCHEMA]:
-            if channel['name'] in self.catalog_dict[SCHEMA]:
+            if channel['name'] in self.catalog_dict[SCHEMA] and channel['name'] not in self.RESET_CHANNELS:
                 self.catalog_dict[SCHEMA][channel['name']] = jsonupdate_ng.updateJson(self.catalog_dict[SCHEMA][channel['name']], channel, meta={'listPatchScheme': {'$.entries': {'key': 'name'}}})
             else:
+                # If reset channel or new channel, take full definition from patch.
                 self.catalog_dict[SCHEMA][channel['name']] = channel
 
+        # Keep only the latest EA drop in the alpha channel to support fresh install only.
+        if 'alpha' in self.catalog_dict[SCHEMA]:
+            self.prune_channel_to_latest_ea(SCHEMA, 'alpha')
+
+    # updates a given OLM channel so that only the latest Early Access (EA) version remains in entries.
+    def prune_channel_to_latest_ea(self, schema, channel_name):
+        channel = self.catalog_dict[schema][channel_name]
+        entries = [e for e in (channel.get('entries') or []) if e.get('name')]
+        ea = [e for e in entries if 'ea' in (e.get('name') or '')]
+        if not ea:
+            raise ValueError(f"Channel {channel_name!r} has no EA versions.")
+        # How largest is decided: key = (release, ea_segments). Tuples compared left-to-right (lexicographic).
+        # Example keys:
+        #   3.4.0-ea.1   -> ((3, 4, 0), (1,))
+        #   3.4.0-ea.1.1 -> ((3, 4, 0), (1, 1))
+        #   3.14.0-ea.2  -> ((3, 14, 0), (2,))
+        # Step 1: compare release; (3,4,0) < (3,14,0) so 3.14.0-ea.2 wins over 3.4.0-ea.*.
+        # Step 2: if release equal, compare ea_segments; (1,) < (1,1) so ea.1.1 > ea.1. max() picks entry with largest key.
+        latest_ea_entry = max(ea, key=lambda e: self.parse_ea_entry_name(e['name']))
+        channel['entries'] = [{'name': latest_ea_entry['name']}]
+
+    def parse_ea_entry_name(self, entry_name: str):
+        """
+        Parse EA OLM entry name into a comparable tuple for ordering. Raises ValueError if invalid.
+
+        entry_name must be in the below format:
+        - rhods-operator.X.Y.Z-ea.N
+        - rhods-operator.X.Y.Z-ea.N.H
+        X = 0-9, Y/Z = 0-99, N/H = non-negative integers.
+
+        Returns:
+            (release, ea_segments): Comparable tuple for ordering. Example:
+                parse_ea_entry_name("rhods-operator.3.4.0-ea.1.1") -> ((3, 4, 0), (1, 1))
+        """
+        entry_name = entry_name.strip()
+        prefix = self.PACKAGE_NAME + "."
+        version_str = entry_name[len(prefix):] if entry_name.startswith(prefix) else ""
+        if not version_str or not self.EA_VERSION_PATTERN.match(version_str):
+            raise ValueError(
+                f"Invalid EA version for entry {entry_name!r}: must be {prefix!r} followed by "
+                "X.Y.Z-ea.N or X.Y.Z-ea.N.H (e.g. 3.4.0-ea.1, 3.4.0-ea.1.1)"
+            )
+        s = version_str
+        base, _, suffix = s.partition("-ea")
+        base = base.strip(".-")
+        suffix = suffix.strip(".")
+        try:
+            parts = [x for x in base.split(".") if x]
+            if len(parts) != 3:
+                raise ValueError(f"Release must be exactly X.Y.Z, got {base!r}")
+            release = tuple(int(x) for x in parts)
+            x_val, y_val, z_val = release
+            if not (0 <= x_val <= 9):
+                raise ValueError(f"X must be 0-9, got {x_val}")
+            if not (0 <= y_val <= 99 and 0 <= z_val <= 99):
+                raise ValueError(f"Y and Z must be 0-99, got {y_val}, {z_val}")
+        except ValueError as err:
+            raise ValueError(f"Invalid EA version for entry {entry_name!r}: {err}") from err
+        if not suffix:
+            ea_segments = (0,)
+        else:
+            try:
+                ea_segments = tuple(int(x) for x in suffix.split(".") if x)
+            except ValueError as err:
+                raise ValueError(f"Invalid EA version for entry {entry_name!r}: {err}") from err
+            if not ea_segments:
+                ea_segments = (0,)
+        return (release, ea_segments)
 
     def patch_olm_bundles(self):
         return self.patch_current_release_bundle_schema()
+
 
 class snapshot_processor:
     GIT_URL_LABEL_KEY = 'git.url'

--- a/utils/stage-promoter/stage_promoter.py
+++ b/utils/stage-promoter/stage_promoter.py
@@ -20,7 +20,7 @@ class stage_promoter:
     PRODUCTION_REGISTRY = 'registry.redhat.io'
     PACKAGE_NAME = 'rhods-operator'
     # Channel names that are reset from patch (no merge with base catalog).
-    RESET_CHANNELS = {'alpha'}
+    RESET_CHANNELS = {'beta'}
     # Version after PACKAGE_NAME.: X.Y.Z-ea.N or X.Y.Z-ea.N.H (H optional). X=0-9, Y/Z=0-99.
     EA_VERSION_PATTERN = re.compile(r"^[0-9]\.[0-9]{1,2}\.[0-9]{1,2}-ea\.[0-9]+(\.[0-9]+)?$")
 
@@ -102,9 +102,9 @@ class stage_promoter:
                 # If reset channel or new channel, take full definition from patch.
                 self.catalog_dict[SCHEMA][channel['name']] = channel
 
-        # Keep only the latest EA drop in the alpha channel to support fresh install only.
-        if 'alpha' in self.catalog_dict[SCHEMA]:
-            self.prune_channel_to_latest_ea(SCHEMA, 'alpha')
+        # Keep only the latest EA drop in the beta channel to support fresh install only.
+        if 'beta' in self.catalog_dict[SCHEMA]:
+            self.prune_channel_to_latest_ea(SCHEMA, 'beta')
 
     # updates a given OLM channel so that only the latest Early Access (EA) version remains in entries.
     def prune_channel_to_latest_ea(self, schema, channel_name):


### PR DESCRIPTION
## Context

As per the requirements outlined in the [Red Hat AI Release FAQs](https://docs.google.com/document/d/1ToX_LasDYMAo4v7Ou1ip7Qkk7_oR-2TG2RVvU_Kb4tU/edit?tab=t.0):

- **CI / Nightly**  
  Catalogs must include a **beta** channel with **upgrade paths** for testing.

- **Final catalog**  
  Catalogs must include an **beta** channel that contains **only the latest EA drop** and strictly supports **fresh installations only**. Customers **must not be able to upgrade** from or to an EA drop.

To support both use cases, we apply different handling at different stages.

---

## Implementation

- **CI / Nightly builds: Reset the beta channel from `catalog-patch`**  
  The beta channel is fully defined by the patch and is **not merged** with the base catalog.  
  As a result, the channel entries are reset on every build with the required EA drops and upgrade paths for testing purposes.  
  *(Applies to both the **FBC processor** and the **stage promoter**.)*

- **Stage catalog builds: Prune the beta channel to the latest EA only**  
  All entries except the **latest EA** are removed, leaving it as the channel head with **no defined upgrade edges**.  
  *(Applies to the **stage promoter** only.)*
