### PR TITLE
Update catalog validator to handle EA releases

### DIFF
--- a/utils/validators/bootstrap.sh
+++ b/utils/validators/bootstrap.sh
@@ -1,0 +1,47 @@
+# Usage
+#
+# export BRANCH variables before running this 
+#  script as required.
+#
+#    export BRANCH=rhoai-3.4-ea.2
+#    ./bootstrap.sh
+# 
+# run ./bootstrap.sh --pull-repos if you want to re-pull RHOAI-Build-Config.
+
+set -eo pipefail
+
+BRANCH=${BRANCH:-rhoai-3.4-ea.2}
+
+
+if [[ "$1" == "--pull-repos"  || ! -d main || ! -d "${BRANCH}" ]]; then
+  rm -rf "${BRANCH}" main
+  git init main
+  git -C main remote add origin https://github.com/red-hat-data-services/RHOAI-Build-Config.git 
+
+  # shallow fetch, use `git fetch --unshallow` to get full fetch`
+  git -C main fetch origin --depth=1 main "${BRANCH}" 
+  git -C main checkout main
+  git -C main worktree add ../"${BRANCH}" origin/"${BRANCH}"
+fi
+
+function python3 () {
+  uv run $@
+}
+
+PCC_FOLDER_PATH=main/pcc
+BUILD_CONFIG_PATH=main/config/config.yaml
+SHIPPED_RHOAI_VERSIONS_PATH=main/pcc/shipped_rhoai_versions_granular.txt
+PCC_FOLDER_PATH=main/pcc
+GLOBAL_CONFIG_PATH=main/config/config.yaml
+
+echo PCC Cache Validation
+# python3 ./catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ${GLOBAL_CONFIG_PATH}
+
+BUILD_CONFIG_PATH=${BRANCH}/config/build-config.yaml
+SHIPPED_RHOAI_VERSIONS_PATH=main/pcc/shipped_rhoai_versions_granular.txt
+CATALOG_FOLDER_PATH=${BRANCH}/catalog
+GLOBAL_CONFIG_PATH=main/config/config.yaml
+
+echo Running Catalog Validation
+python3 ./catalog_validator.py -op validate-catalogs --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${CATALOG_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ${GLOBAL_CONFIG_PATH}
+

--- a/utils/validators/catalog_validator.py
+++ b/utils/validators/catalog_validator.py
@@ -62,6 +62,12 @@ class catalog_validator:
         def __le__(self, other):
             return self._parsed_tuple <= other._parsed_tuple
 
+        def __gt__(self, other):
+            return self._parsed_tuple > other._parsed_tuple
+
+        def __lt__(self, other):
+            return self._parsed_tuple < other._parsed_tuple
+
     def __init__(self, build_config_path, catalog_folder_path, shipped_rhoai_versions_path, operation, global_config_path):
         self.build_config_path = build_config_path
         self.catalog_folder_path = catalog_folder_path
@@ -114,17 +120,23 @@ class catalog_validator:
                     and numeric_ocp_version < self.MIN_OCP_VERSION_FOR_RHOAI_30
                 )
 
-                if operator_name not in bundles and operator_name not in self.MISSING_BUNDLE_EXCEPTIONS:
+                if operator_name in bundles:
                     if is_3x_on_unsupported_ocp:
-                        print(f"Skipping the catalog validation for {rhoai_version} bundle for OCP {ocp_version}, since 3.x is not shipped on this OCP version!")
-                        continue
-                    if not self.rhods_operator(operator_name) >= self.rhods_operator(self.discontinuity_map[ocp_version]) and not self.rhods_operator(operator_name) <= self.rhods_operator(self.onboarding_map[ocp_version]):
-                        missing_bundles[ocp_version].append(operator_name)
-                    else:
-                        print(f'Ignoring since OCP {ocp_version} is not supported for {operator_name}')
+                        incorrect_3x_bundles[ocp_version].append(operator_name)
+                    continue
 
-                if operator_name in bundles and is_3x_on_unsupported_ocp:
-                    incorrect_3x_bundles[ocp_version].append(operator_name)
+                if operator_name in self.MISSING_BUNDLE_EXCEPTIONS:
+                    continue
+
+                if is_3x_on_unsupported_ocp:
+                    print(f"Skipping the catalog validation for {rhoai_version} bundle for OCP {ocp_version}, since 3.x is not shipped on this OCP version!")
+                    continue
+
+                if self.rhods_operator(operator_name) >= self.rhods_operator(self.discontinuity_map[ocp_version]) \
+                        or self.rhods_operator(operator_name) < self.rhods_operator(self.onboarding_map[ocp_version]):
+                    print(f'Ignoring since OCP {ocp_version} is not supported for {operator_name}')
+                else:
+                    missing_bundles[ocp_version].append(operator_name)
 
         print('missing_bundles', missing_bundles)
         print('incorrect_3x_bundles', incorrect_3x_bundles)
@@ -167,13 +179,23 @@ class catalog_validator:
                     rhoai_version.startswith('3')
                     and numeric_ocp_version < self.MIN_OCP_VERSION_FOR_RHOAI_30
                 )
+                missing_from_bundle = (operator_name not in bundles)
 
-                if operator_name not in bundles and operator_name not in self.MISSING_BUNDLE_EXCEPTIONS:
-                    if not (is_3x_on_unsupported_ocp):
-                        if not self.rhods_operator(operator_name) >= self.rhods_operator(self.discontinuity_map[ocp_version]) and not self.rhods_operator(operator_name) <= self.rhods_operator(self.onboarding_map[ocp_version]):
-                            missing_bundles[pcc_file].append(operator_name)
-                        else:
-                            print(f'Ignoring since OCP {ocp_version} is not supported for {operator_name}')
+                if operator_name in bundles:
+                    continue
+
+                if operator_name in self.MISSING_BUNDLE_EXCEPTIONS:
+                    continue
+
+                if is_3x_on_unsupported_ocp:  # bypassing check for 3.0 for OCP < 4.19
+                    continue
+
+                if self.rhods_operator(operator_name) >= self.rhods_operator(self.discontinuity_map[ocp_version]) \
+                        or self.rhods_operator(operator_name) < self.rhods_operator(self.onboarding_map[ocp_version]):
+
+                    print(f'Ignoring since OCP {ocp_version} is not supported for {operator_name}')
+                else:
+                    missing_bundles[pcc_file].append(operator_name)
 
 
 

--- a/utils/validators/catalog_validator.py
+++ b/utils/validators/catalog_validator.py
@@ -68,6 +68,28 @@ class catalog_validator:
         def __lt__(self, other):
             return self._parsed_tuple < other._parsed_tuple
 
+        def __getitem__(self, key):
+            return self._parsed_tuple[key]
+
+        def __repr__(self):
+            return self.version
+
+        # given a list of versions, determine if this is the latest ea version for a given (major, minor, patch)
+        def is_latest_ea(self, versions_list):
+            latest = self._parsed_tuple
+            for item in versions_list:
+                try: 
+                    version = self.__class__(item) 
+                except ValueError:
+                    continue
+                else:
+                    if version[0:4] != latest[0:4]:
+                        continue
+                    if version[4:] > latest[4:]:
+                        latest = version
+            print(f"{latest} is the newest version in the vicinity of {self.version}")
+            return latest == self._parsed_tuple
+            
     def __init__(self, build_config_path, catalog_folder_path, shipped_rhoai_versions_path, operation, global_config_path):
         self.build_config_path = build_config_path
         self.catalog_folder_path = catalog_folder_path
@@ -134,9 +156,14 @@ class catalog_validator:
 
                 if self.rhods_operator(operator_name) >= self.rhods_operator(self.discontinuity_map[ocp_version]) \
                         or self.rhods_operator(operator_name) < self.rhods_operator(self.onboarding_map[ocp_version]):
-                    print(f'Ignoring since OCP {ocp_version} is not supported for {operator_name}')
-                else:
-                    missing_bundles[ocp_version].append(operator_name)
+                    print(f'Ignoring missing {operator_name} since OCP {ocp_version} is not supported for it')
+                    continue
+
+                if not self.rhods_operator(operator_name).is_latest_ea(bundles):
+                    print(f'Ignoring missing {operator_name} since it is expected to be overwritten by a newer EA release')
+                    continue
+
+                missing_bundles[ocp_version].append(operator_name)
 
         print('missing_bundles', missing_bundles)
         print('incorrect_3x_bundles', incorrect_3x_bundles)
@@ -193,7 +220,7 @@ class catalog_validator:
                 if self.rhods_operator(operator_name) >= self.rhods_operator(self.discontinuity_map[ocp_version]) \
                         or self.rhods_operator(operator_name) < self.rhods_operator(self.onboarding_map[ocp_version]):
 
-                    print(f'Ignoring since OCP {ocp_version} is not supported for {operator_name}')
+                    print(f'Ignoring missing {operator_name} since OCP {ocp_version} is not supported for it')
                 else:
                     missing_bundles[pcc_file].append(operator_name)
 


### PR DESCRIPTION
## Summary

Refactors and fixes the catalog validator's bundle validation logic for both `validate_catalogs` and `validate_pcc`.

## Changes


### Handle EA catalog overwriting (`catalog_validator.py`)

When a newer EA drop (e.g. `ea.2`) overwrites an older one (`ea.1`) in the catalog, the validator was incorrectly flagging the older version as missing. Added an `is_latest_ea` method to the `rhods_operator` class that checks whether a given EA version is the latest for its (major, minor, patch) group within the catalog's bundle list. If a newer EA version exists, the missing older one is expected and skipped.

Also added `__gt__`, `__lt__`, `__getitem__`, and `__repr__` methods to `rhods_operator` to support the comparison and slicing needed by `is_latest_ea`.

### Flatten validation logic (`catalog_validator.py`)

The nested `if` conditions in both `validate_catalogs` and `validate_pcc` were restructured into a flat, early-return style for readability.

After flattening, each check is a separate `continue` guard:
1. Bundle already present in catalog — skip (and flag if it's 3.x on unsupported OCP)
2. Bundle is a known exception — skip
3. Bundle is 3.x on OCP < 4.19 — skip
4. Bundle is outside the OCP version's discontinuity/onboarding boundaries — skip
5. Otherwise — report as missing


### Bootstrap script (`bootstrap.sh`)

Added a bootstrap script for local validator troubleshooting. It shallow-clones the relevant RHOAI-Build-Config branches and runs `validate-catalogs` via `uv run`.