### PR TITLE
fix: skip EA pruning when beta channel has no EA versions

### DIFF
--- a/utils/stage-promoter/stage_promoter.py
+++ b/utils/stage-promoter/stage_promoter.py
@@ -112,7 +112,8 @@ class stage_promoter:
         entries = [e for e in (channel.get('entries') or []) if e.get('name')]
         ea = [e for e in entries if 'ea' in (e.get('name') or '')]
         if not ea:
-            raise ValueError(f"Channel {channel_name!r} has no EA versions.")
+            print(f"Channel {channel_name!r} has no EA versions, skipping pruning.")
+            return
         # How largest is decided: key = (release, ea_segments). Tuples compared left-to-right (lexicographic).
         # Example keys:
         #   3.4.0-ea.1   -> ((3, 4, 0), (1,))


### PR DESCRIPTION
For z-stream releases (rhoai-2.16, rhoai-2.25) on OCP versions below 4.19, the beta channel contains only GA entries with no EA versions. The prune_channel_to_latest_ea function was raising a ValueError in this case, crashing the stage promoter pipeline.

Skip pruning gracefully when no EA entries are found, leaving the beta channel entries intact. This has no impact on EA releases (rhoai-3.4+) where EA entries exist and pruning continues as before.