### PR TITLE
revert: restore EA version validation in prune_channel_to_latest_ea

### DIFF
--- a/utils/stage-promoter/stage_promoter.py
+++ b/utils/stage-promoter/stage_promoter.py
@@ -112,8 +112,7 @@ class stage_promoter:
         entries = [e for e in (channel.get('entries') or []) if e.get('name')]
         ea = [e for e in entries if 'ea' in (e.get('name') or '')]
         if not ea:
-            print(f"Channel {channel_name!r} has no EA versions, skipping pruning.")
-            return
+            raise ValueError(f"Channel {channel_name!r} has no EA versions.")
         # How largest is decided: key = (release, ea_segments). Tuples compared left-to-right (lexicographic).
         # Example keys:
         #   3.4.0-ea.1   -> ((3, 4, 0), (1,))


### PR DESCRIPTION
Reverts the temporary fix from PR #24 that skipped EA pruning when no EA versions were found. The rhoai-2.16 stage push has completed successfully, so restoring the original ValueError to maintain strict validation for future releases.