### PR TITLE
Update is_latest_ea logic

### DIFF
--- a/utils/validators/bootstrap.sh
+++ b/utils/validators/bootstrap.sh
@@ -35,7 +35,7 @@ PCC_FOLDER_PATH=main/pcc
 GLOBAL_CONFIG_PATH=main/config/config.yaml
 
 echo PCC Cache Validation
-# python3 ./catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ${GLOBAL_CONFIG_PATH}
+python3 ./catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ${GLOBAL_CONFIG_PATH}
 
 BUILD_CONFIG_PATH=${BRANCH}/config/build-config.yaml
 SHIPPED_RHOAI_VERSIONS_PATH=main/pcc/shipped_rhoai_versions_granular.txt

--- a/utils/validators/catalog_validator.py
+++ b/utils/validators/catalog_validator.py
@@ -68,27 +68,33 @@ class catalog_validator:
         def __lt__(self, other):
             return self._parsed_tuple < other._parsed_tuple
 
+        def __eq__(self, other):
+            return self._parsed_tuple == other._parsed_tuple
+
         def __getitem__(self, key):
             return self._parsed_tuple[key]
 
         def __repr__(self):
             return self.version
 
-        # given a list of versions, determine if this is the latest ea version for a given (major, minor, patch)
+        # given a list of versions, determine if this is the globally latest ea version 
         def is_latest_ea(self, versions_list):
-            latest = self._parsed_tuple
+            latest = self
+
             for item in versions_list:
+                # This try block filters out all the legacy releases that don't match 
+                #  the expected pattern
                 try: 
                     version = self.__class__(item) 
                 except ValueError:
                     continue
                 else:
-                    if version[0:4] != latest[0:4]:
-                        continue
-                    if version[4:] > latest[4:]:
+                    # Check if greater, but skip if GA release
+                    if version >= latest and version[3] == 0:
                         latest = version
-            print(f"{latest} is the newest version in the vicinity of {self.version}")
-            return latest == self._parsed_tuple
+
+            print(f"{latest} is the newest EA release")
+            return latest == self
             
     def __init__(self, build_config_path, catalog_folder_path, shipped_rhoai_versions_path, operation, global_config_path):
         self.build_config_path = build_config_path


### PR DESCRIPTION
The is_latest_ea() function has been updated to check if the version is the globally highest ea version, rather than the locally highest one.

This makes it consistent with our existing beta channel updating logic.