### PR TITLE
Add ocp version check before ea checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/*
+**/__pycache__/
 utils/operator-processor/*.yaml
 utils/operator-processor/*.json
 utils/release-helper/release-*/**

--- a/utils/bundle-processor/bundle-processor.py
+++ b/utils/bundle-processor/bundle-processor.py
@@ -390,7 +390,8 @@ class quay_controller:
             sys.exit(1)
 
     def get_git_labels(self, repo, tag):
-        url = f'{BASE_URL}/repository/{self.org}/{repo}/manifest/{tag}/labels?filter=git'
+        url = f'{BASE_URL}/repository/{self.org}/{repo}/manifest/{tag}/labels'
+        # ?filter=git, throwing 403 forbidden, due to this need to check, seems quay issue, disabling the fitler for now
         headers = {'Authorization': f'Bearer {os.environ[self.org.upper() + "_QUAY_API_TOKEN"]}',
                    'Accept': 'application/json'}
         response = requests.get(url, headers=headers)

--- a/utils/fbc-processor/.gitignore
+++ b/utils/fbc-processor/.gitignore
@@ -1,0 +1,4 @@
+rhoai-*
+main/
+temp/
+work_dir/

--- a/utils/fbc-processor/bootstrap-auth.sh
+++ b/utils/fbc-processor/bootstrap-auth.sh
@@ -1,0 +1,6 @@
+# run this before bootstrap.sh, using source:
+#   source ./bootstrap-auth.sh
+#   ./bootstrap.sh
+export VAULT_ADDR=https://vault.devshift.net
+vault login -method=oidc --no-print
+export RHOAI_QUAY_API_TOKEN=$(vault kv get --mount=rhoai -field=oauth_token creds/quay/quay-devops-app)

--- a/utils/fbc-processor/bootstrap.sh
+++ b/utils/fbc-processor/bootstrap.sh
@@ -1,0 +1,130 @@
+# Usage
+#
+# export BRANCH and PREVIOUS_BRANCH variables before running this 
+#  script as required.
+# make sure you already have oc configured to point to p02 cluster,
+# and quay credentials to read RHOAI quay org.
+#
+# Before running this script, source the `bootstrap-auth.sh` script 
+#  to get the required oauth token for quay API.
+#
+#    source ./bootstrap-auth.sh # -> only need to run this once per terminal session
+#
+#    export BRANCH=rhoai-3.4-ea.2
+#    export PREVIOUS_BRANCH=rhoai-2.25
+#    ./bootstrap.sh
+# 
+# run ./bootstrap.sh --pull-repos if you want to re-pull RHOAI-Build-Config.
+
+set -eo pipefail
+
+BRANCH=${BRANCH:-rhoai-3.4-ea.2}
+PREVIOUS_BRANCH=${PREVIOUS_BRANCH:-rhoai-2.25}
+
+
+if [[ "$1" == "--pull-repos"  || ! -d main || ! -d "${BRANCH}" || ! -d "${PREVIOUS_BRANCH}" ]]; then
+  rm -rf "${BRANCH}" "${PREVIOUS_BRANCH}" main
+  git init main
+  git -C main remote add origin https://github.com/red-hat-data-services/RHOAI-Build-Config.git 
+
+  # shallow fetch, use `git fetch --unshallow` to get full fetch`
+  git -C main fetch origin --depth=1 main "${BRANCH}" "${PREVIOUS_BRANCH}"
+  git -C main checkout main
+  git -C main worktree add ../"${BRANCH}" origin/"${BRANCH}"
+  git -C main worktree add ../"${PREVIOUS_BRANCH}" origin/"${PREVIOUS_BRANCH}"
+fi
+
+
+BUILD_CONFIG_PATH=${BRANCH}/config/build-config.yaml
+PREVIOUS_BUILD_CONFIG_PATH=${PREVIOUS_BRANCH}/config/build-config.yaml
+
+RHOAI_VERSION=v${BRANCH/rhoai-/}
+COMPONENT_SUFFIX=${RHOAI_VERSION//./-}
+PREVIOUS_RHOAI_VERSION=v${PREVIOUS_BRANCH/rhoai-/}
+PREVIOUS_COMPONENT_SUFFIX=${PREVIOUS_RHOAI_VERSION//./-}
+OPERATOR_BUNDLE_COMPONENT_NAME=odh-operator-bundle
+
+PATCH_YAML_PATH=${BRANCH}/catalog/catalog-patch.yaml
+PREVIOUS_PATCH_YAML_PATH=${PREVIOUS_BRANCH}/catalog/catalog-patch.yaml
+
+# Not needed, assuming user is running this locally
+# OC_TOKEN=$(echo $OC_TOKEN | awk '{$1=$1};1' | tr -d '\n')
+# BASE64_AUTH=$(echo -n "${RHOAI_QUAY_RO_USERNAME}:${RHOAI_QUAY_RO_TOKEN}" | base64 -w 0)
+# mkdir -p ${HOME}/.docker
+# echo '{"auths":{"quay.io/rhoai/odh-operator-bundle":{"username":"'"${RHOAI_QUAY_RO_USERNAME}"'","password":"'"${RHOAI_QUAY_RO_TOKEN}"'","email":"","auth":"'"${BASE64_AUTH}"'"}}}' > ${HOME}/.docker/config.json
+
+OPERATOR_BUNDLE_IMAGE_NAME=RELATED_IMAGE_ODH_OPERATOR_BUNDLE_IMAGE
+echo "OPERATOR_BUNDLE_IMAGE_NAME = $OPERATOR_BUNDLE_IMAGE_NAME"
+
+APPLICATION_NAME=rhoai-${COMPONENT_SUFFIX}
+echo "APPLICATION_NAME = $APPLICATION_NAME"
+
+#Invoke the FBC processor to extract the snapshot images
+CATALOG_BUILD_ARGS_FILE_PATH=${BRANCH}/catalog/catalog_build_args.map
+
+function python3 () {
+  uv run $@
+}
+FBC_PROCESSOR_PATH=${FBC_PROCESSOR_PATH}/
+FBC_PROCESSOR_PATH=.
+
+TEMP_DIR="./temp"
+mkdir -p ${TEMP_DIR}
+
+python3 ${FBC_PROCESSOR_PATH}/fbc-processor.py -op extract-snapshot-images -o ${TEMP_DIR}/snapshot_images.json -v ${BRANCH} -f ${OPERATOR_BUNDLE_COMPONENT_NAME} -b ${BUILD_CONFIG_PATH} --catalog-build-args-file-path ${CATALOG_BUILD_ARGS_FILE_PATH}
+
+cp ./fbc-semver-template.yaml ${TEMP_DIR}/
+LATEST_BUNDLE_IMAGE=$(jq --arg OPERATOR_BUNDLE_IMAGE_NAME "$OPERATOR_BUNDLE_IMAGE_NAME" -r '.[]   | select(.name == $OPERATOR_BUNDLE_IMAGE_NAME) | .value' ${TEMP_DIR}/snapshot_images.json)
+echo "LATEST_BUNDLE_IMAGE = $LATEST_BUNDLE_IMAGE"
+yq e -i '.stable.bundles[0].image = "$LATEST_BUNDLE_IMAGE"' "${TEMP_DIR}/fbc-semver-template.yaml"
+LATEST_BUNDLE_IMAGE="$LATEST_BUNDLE_IMAGE" yq e -i '.stable.bundles[0].image = env(LATEST_BUNDLE_IMAGE)' "${TEMP_DIR}/fbc-semver-template.yaml"
+
+#Previous Release - Invoke the FBC processor to extract the snapshot images
+cp -f "${TEMP_DIR}/fbc-semver-template.yaml" "${TEMP_DIR}/previous-fbc-semver-template.yaml"
+PREVIOUS_CATALOG_BUILD_ARGS_FILE_PATH=${PREVIOUS_BRANCH}/catalog/catalog_build_args.map
+python3 ${FBC_PROCESSOR_PATH}/fbc-processor.py -op extract-snapshot-images -o ${TEMP_DIR}/previous_snapshot_images.json -v ${PREVIOUS_BRANCH} -f ${OPERATOR_BUNDLE_COMPONENT_NAME} -b ${PREVIOUS_BUILD_CONFIG_PATH} --catalog-build-args-file-path ${PREVIOUS_CATALOG_BUILD_ARGS_FILE_PATH}
+PREVIOUS_LATEST_BUNDLE_IMAGE=$(jq --arg OPERATOR_BUNDLE_IMAGE_NAME "$OPERATOR_BUNDLE_IMAGE_NAME" -r '.[]   | select(.name == $OPERATOR_BUNDLE_IMAGE_NAME) | .value' ${TEMP_DIR}/previous_snapshot_images.json)
+echo "PREVIOUS_LATEST_BUNDLE_IMAGE = $PREVIOUS_LATEST_BUNDLE_IMAGE"
+yq e -i '.stable.bundles[0].image = "$PREVIOUS_LATEST_BUNDLE_IMAGE"' ${TEMP_DIR}/previous-fbc-semver-template.yaml
+PREVIOUS_LATEST_BUNDLE_IMAGE="$PREVIOUS_LATEST_BUNDLE_IMAGE" yq e -i '.stable.bundles[0].image = env(PREVIOUS_LATEST_BUNDLE_IMAGE)' ${TEMP_DIR}/previous-fbc-semver-template.yaml
+
+
+#Generate the single bundle catalog === sbc
+CSV_META_MIN_OCP_VERSION=417
+WORK_DIR=work_dir
+mkdir -p ${WORK_DIR}
+BUNDLE_OBJECT_SINGLE_BUNDLE_PATH=${WORK_DIR}/bundle_object_sbc_semver.yaml
+CSV_META_SINGLE_BUNDLE_PATH=${WORK_DIR}/csv_meta_sbc_semver.yaml
+CSV_META_OPM_FLAG="--migrate-level=bundle-object-to-csv-metadata"
+DOCKER_CONFIG=${HOME}/.docker/ opm alpha render-template semver -o yaml ${TEMP_DIR}/fbc-semver-template.yaml > ${BUNDLE_OBJECT_SINGLE_BUNDLE_PATH}
+DOCKER_CONFIG=${HOME}/.docker/ opm alpha render-template semver ${CSV_META_OPM_FLAG} -o yaml ${TEMP_DIR}/fbc-semver-template.yaml > ${CSV_META_SINGLE_BUNDLE_PATH}
+#Previous Release - Generate the single bundle catalog === sbc
+PREVIOUS_BUNDLE_OBJECT_SINGLE_BUNDLE_PATH=${WORK_DIR}/previous_bundle_object_sbc_semver.yaml
+PREVIOUS_CSV_META_SINGLE_BUNDLE_PATH=${WORK_DIR}/previous_csv_meta_sbc_semver.yaml
+DOCKER_CONFIG=${HOME}/.docker/ opm alpha render-template semver -o yaml ${TEMP_DIR}/previous-fbc-semver-template.yaml > ${PREVIOUS_BUNDLE_OBJECT_SINGLE_BUNDLE_PATH}
+DOCKER_CONFIG=${HOME}/.docker/ opm alpha render-template semver ${CSV_META_OPM_FLAG} -o yaml ${TEMP_DIR}/previous-fbc-semver-template.yaml > ${PREVIOUS_CSV_META_SINGLE_BUNDLE_PATH}
+PCC_BUNDLE_OBJECT_CATALOG_YAML_PATH=main/pcc/bundle_object_catalog.yaml
+PCC_CSV_META_CATALOG_YAML_PATH=main/pcc/csv_meta_catalog.yaml
+PUSH_PIPELINE_PATH=${BRANCH}/.tekton/rhoai-fbc-fragment-${COMPONENT_SUFFIX}-push.yaml
+PREVIOUS_PUSH_PIPELINE_PATH=${PREVIOUS_BRANCH}/.tekton/rhoai-fbc-fragment-${PREVIOUS_COMPONENT_SUFFIX}-push.yaml
+
+while IFS= read -r value;
+do
+    #Declare FBC processing variables
+    OPENSHIFT_VERSION=$value
+    NUMERIC_OCP_VERSION=${OPENSHIFT_VERSION/v4./4}
+    echo "OPENSHIFT_VERSION=$OPENSHIFT_VERSION"
+    OUTPUT_CATALOG_PATH=${BRANCH}/catalog/${OPENSHIFT_VERSION}/rhods-operator/catalog.yaml
+    
+    PCC_CATALOG_YAML_PATH=main/pcc/catalog-${OPENSHIFT_VERSION}.yaml
+    SINGLE_BUNDLE_PATH=${BUNDLE_OBJECT_SINGLE_BUNDLE_PATH}
+    if [[ $NUMERIC_OCP_VERSION -ge $CSV_META_MIN_OCP_VERSION ]]; then SINGLE_BUNDLE_PATH=${CSV_META_SINGLE_BUNDLE_PATH}; fi
+    python3 ${FBC_PROCESSOR_PATH}/fbc-processor.py -op catalog-patch -b ${BUILD_CONFIG_PATH} -c ${PCC_CATALOG_YAML_PATH} -p ${PATCH_YAML_PATH} -s ${SINGLE_BUNDLE_PATH} -o ${OUTPUT_CATALOG_PATH} --push-pipeline-yaml-path ${PUSH_PIPELINE_PATH} --push-pipeline-operation enable 
+    
+    PREVIOUS_SINGLE_BUNDLE_PATH=${PREVIOUS_BUNDLE_OBJECT_SINGLE_BUNDLE_PATH}
+    if [[ $NUMERIC_OCP_VERSION -ge $CSV_META_MIN_OCP_VERSION ]]; then PREVIOUS_SINGLE_BUNDLE_PATH=${PREVIOUS_CSV_META_SINGLE_BUNDLE_PATH}; fi
+    python3 ${FBC_PROCESSOR_PATH}/fbc-processor.py -op catalog-patch -b ${PREVIOUS_BUILD_CONFIG_PATH} -c ${OUTPUT_CATALOG_PATH} -p ${PREVIOUS_PATCH_YAML_PATH} -s ${PREVIOUS_SINGLE_BUNDLE_PATH} -o ${OUTPUT_CATALOG_PATH} --push-pipeline-yaml-path ${PREVIOUS_PUSH_PIPELINE_PATH} --push-pipeline-operation enable
+    
+    
+    #cat ${OUTPUT_CATALOG_PATH}
+done < <(yq eval '.config.supported-ocp-versions.build[].name' $BUILD_CONFIG_PATH)

--- a/utils/fbc-processor/fbc-processor.py
+++ b/utils/fbc-processor/fbc-processor.py
@@ -245,7 +245,8 @@ class quay_controller:
         return tag
 
     def get_git_labels(self, repo, tag):
-        url = f'{BASE_URL}/repository/{self.org}/{repo}/manifest/{tag}/labels' #?filter=git
+        url = f'{BASE_URL}/repository/{self.org}/{repo}/manifest/{tag}/labels'
+        # ?filter=git, throwing 403 forbidden, due to this need to check, seems quay issue, disabling the fitler for now
         headers = {'Authorization': f'Bearer {os.environ[self.org.upper() + "_QUAY_API_TOKEN"]}',
                    'Accept': 'application/json'}
         response = requests.get(url, headers=headers)

--- a/utils/fbc-processor/fbc-processor.py
+++ b/utils/fbc-processor/fbc-processor.py
@@ -10,6 +10,9 @@ import base64
 import sys
 class fbc_processor:
     PRODUCTION_REGISTRY = 'registry.redhat.io'
+    # Channel names that are reset from patch (no merge with base catalog).
+    RESET_CHANNELS = {'alpha'}
+
     def __init__(self, build_config_path:str, catalog_yaml_path:str, patch_yaml_path:str, single_bundle_path:str, output_file_path:str, push_pipeline_operation:str, push_pipeline_yaml_path:str):
         self.build_config_path = build_config_path
         self.catalog_yaml_path = catalog_yaml_path
@@ -93,10 +96,12 @@ class fbc_processor:
         SCHEMA = 'olm.channel'
         PATCH_SCHEMA = 'olm.channels'
         for channel in self.patch_dict['patch'][PATCH_SCHEMA]:
-            if channel['name'] in self.catalog_dict[SCHEMA]:
+            if channel['name'] in self.catalog_dict[SCHEMA] and channel['name'] not in self.RESET_CHANNELS:
                 self.catalog_dict[SCHEMA][channel['name']] = jsonupdate_ng.updateJson(self.catalog_dict[SCHEMA][channel['name']], channel, meta={'listPatchScheme': {'$.entries': {'key': 'name'}}})
             else:
+                # If reset channel or new channel, take full definition from patch.
                 self.catalog_dict[SCHEMA][channel['name']] = channel
+
 
     def apply_replacements_to_catalog(self, olm_bundle):
         olm_bundle['image'] = self.apply_replacement(olm_bundle['image'])

--- a/utils/fbc-processor/fbc-processor.py
+++ b/utils/fbc-processor/fbc-processor.py
@@ -31,7 +31,7 @@ class fbc_processor:
     def parse_catalog_yaml(self):
         # objs = yaml.safe_load_all(open(self.catalog_yaml_path))
         objs = ruyaml.load_all(open(self.catalog_yaml_path), Loader=ruyaml.RoundTripLoader, preserve_quotes=True)
-        print(type(objs))
+        # print(type(objs))
         catalog_dict = defaultdict(dict)
         for obj in objs:
             catalog_dict[obj['schema']][obj['name']] = obj
@@ -59,7 +59,7 @@ class fbc_processor:
                 self.patch_olm_channels()
 
             self.process_push_pipeline()
-
+            self.purge_unused_olm_bundles()
             self.write_output_catalog()
 
     def write_output_catalog(self):
@@ -149,6 +149,18 @@ class fbc_processor:
         for name in to_delete:
             del self.catalog_dict['olm.bundle'][name]
 
+    def purge_unused_olm_bundles(self):
+        channel_objs = self.catalog_dict['olm.channel']
+        referenced_bundles = set()
+        for channel_name, channel_obj in channel_objs.items():
+            for entry in channel_obj['entries']:
+                bundle_name = entry['name']
+                referenced_bundles.add(bundle_name)
+        to_delete = [name for name in self.catalog_dict['olm.bundle'] if name not in referenced_bundles]
+        self.purge_olm_bundles(to_delete)
+             
+        
+        
     def patch_olm_bundles(self):
         SCHEMA = 'olm.bundle'
         current_bundle_name = self.current_olm_bundle['name']

--- a/utils/fbc-processor/fbc-processor.py
+++ b/utils/fbc-processor/fbc-processor.py
@@ -11,7 +11,7 @@ import sys
 class fbc_processor:
     PRODUCTION_REGISTRY = 'registry.redhat.io'
     # Channel names that are reset from patch (no merge with base catalog).
-    RESET_CHANNELS = {'alpha'}
+    RESET_CHANNELS = {'beta'}
 
     def __init__(self, build_config_path:str, catalog_yaml_path:str, patch_yaml_path:str, single_bundle_path:str, output_file_path:str, push_pipeline_operation:str, push_pipeline_yaml_path:str):
         self.build_config_path = build_config_path

--- a/utils/fbc-processor/fbc-processor.py
+++ b/utils/fbc-processor/fbc-processor.py
@@ -13,13 +13,14 @@ class fbc_processor:
     # Channel names that are reset from patch (no merge with base catalog).
     RESET_CHANNELS = {'beta'}
 
-    def __init__(self, build_config_path:str, catalog_yaml_path:str, patch_yaml_path:str, single_bundle_path:str, output_file_path:str, push_pipeline_operation:str, push_pipeline_yaml_path:str):
+    def __init__(self, build_config_path:str, catalog_yaml_path:str, patch_yaml_path:str, single_bundle_path:str, output_file_path:str, push_pipeline_operation:str, push_pipeline_yaml_path:str, purge_bundles:str):
         self.build_config_path = build_config_path
         self.catalog_yaml_path = catalog_yaml_path
         self.patch_yaml_path = patch_yaml_path
         self.single_bundle_path = single_bundle_path
         self.output_file_path = output_file_path
         self.catalog_dict:defaultdict = self.parse_catalog_yaml()
+        self.purge_olm_bundles(purge_bundles.split(","))
         self.patch_dict = self.parse_patch_yaml()
         self.build_config = yaml.safe_load(open(self.build_config_path))
         self.current_olm_bundle = self.parse_single_bundle_catalog()
@@ -142,6 +143,11 @@ class fbc_processor:
                     value = value.replace(f'{intermediate_registry}/{old}@', f'{self.PRODUCTION_REGISTRY}/{new}@')
         return value
 
+
+    def purge_olm_bundles(self, purge_bundles):
+        to_delete = [name for name in self.catalog_dict['olm.bundle'] if name in purge_bundles]
+        for name in to_delete:
+            del self.catalog_dict['olm.bundle'][name]
 
     def patch_olm_bundles(self):
         SCHEMA = 'olm.bundle'
@@ -276,6 +282,8 @@ if __name__ == '__main__':
                         help='Path of the single-bundle generated using the opm.', dest='single_bundle_path')
     parser.add_argument('-o', '--output-file-path', required=False,
                         help='Path of the output catalog yaml', dest='output_file_path')
+    parser.add_argument('--purge-bundles', required=False, default='',
+                        help='olm.bundles to purge from the catalog yaml', dest='purge_bundles')
     parser.add_argument('-sn', '--snapshot-json-path', required=False,
                         help='Path of the single-bundle generated using the opm.', dest='snapshot_json_path')
     parser.add_argument('-f', '--image-filter', required=False,
@@ -294,7 +302,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.operation.lower() == 'catalog-patch':
-        processor = fbc_processor(build_config_path=args.build_config_path, catalog_yaml_path=args.catalog_yaml_path, patch_yaml_path=args.patch_yaml_path, single_bundle_path=args.single_bundle_path, output_file_path=args.output_file_path, push_pipeline_operation=args.push_pipeline_operation, push_pipeline_yaml_path=args.push_pipeline_yaml_path)
+        processor = fbc_processor(build_config_path=args.build_config_path, catalog_yaml_path=args.catalog_yaml_path, patch_yaml_path=args.patch_yaml_path, single_bundle_path=args.single_bundle_path, output_file_path=args.output_file_path, push_pipeline_operation=args.push_pipeline_operation, push_pipeline_yaml_path=args.push_pipeline_yaml_path, purge_bundles=args.purge_bundles)
         processor.patch_catalog_yaml()
     elif args.operation.lower() == 'extract-snapshot-images':
         processor = snapshot_processor(snapshot_json_path=args.snapshot_json_path, output_file_path=args.output_file_path, image_filter=args.image_filter, rhoai_version=args.rhoai_version, build_config_path=args.build_config_path, catalog_build_args_file_path=args.catalog_build_args_file_path, build_type=args.build_type)

--- a/utils/operator-processor/operator-processor.py
+++ b/utils/operator-processor/operator-processor.py
@@ -257,7 +257,8 @@ class quay_controller:
 
 
     def get_git_labels(self, repo, tag):
-        url = f'{BASE_URL}/repository/{self.org}/{repo}/manifest/{tag}/labels?filter=git'
+        url = f'{BASE_URL}/repository/{self.org}/{repo}/manifest/{tag}/labels'
+        # ?filter=git, throwing 403 forbidden, due to this need to check, seems quay issue, disabling the fitler for now
         headers = {'Authorization': f'Bearer {os.environ[self.org.upper() + "_QUAY_API_TOKEN"]}',
                    'Accept': 'application/json'}
         response = requests.get(url, headers=headers)

--- a/utils/operator-processor/operator-processor.py
+++ b/utils/operator-processor/operator-processor.py
@@ -139,6 +139,7 @@ class operator_processor:
         git_labels_meta = {'map': {}}
         missing_images = []
         for image_entry in [image for image in self.operands_map_dict['relatedImages']  if 'FBC' not in image['name'] and 'BUNDLE' not in image['name'] and 'ODH_OPERATOR' not in image['name'] ]:
+            print(f'Processing image entry - {image_entry}')
             parts = image_entry['value'].split('@')[0].split('/')
             registry = parts[0]
             org = parts[1]
@@ -160,10 +161,13 @@ class operator_processor:
                     latest_images.append(image_entry)
 
                     manifest_digest = tag["manifest_digest"]
+                    print(f'manifest_digest = {manifest_digest}')
                     if tag['is_manifest_list'] == True:
+                        print('Found to be a multi-arch image..')
                         image_manifest_digests = qc.get_image_manifest_digests_for_all_the_supported_archs(repo, manifest_digest)
                         if image_manifest_digests:
                             manifest_digest = image_manifest_digests[0]
+                            print(f'will be using the image with manifest_digest {manifest_digest} to find the tags and lables')
 
 
                     labels = qc.get_git_labels(repo, manifest_digest)

--- a/utils/operator-processor/poc.py
+++ b/utils/operator-processor/poc.py
@@ -50,7 +50,13 @@
 #     count += 1
 #     print(f'{repo.replace("rhoai/", "").replace("-rhel8", "")}-v2-13', end='\t')
 # print(count)
+#
+# from pathlib import Path
+# abs='/home/dchouras/RHODS/DevOps/rhods-operator/Dockerfiles/bundle.Dockerfile'
+# print(f'{Path(abs).parent.absolute()}')
 
-from pathlib import Path
-abs='/home/dchouras/RHODS/DevOps/rhods-operator/Dockerfiles/bundle.Dockerfile'
-print(f'{Path(abs).parent.absolute()}')
+import re
+
+text = 'catalog-v4.17.yaml'
+match = re.search('^catalog-(.*).yaml', text)
+print(match.group(1))

--- a/utils/release-helper/release_processor.py
+++ b/utils/release-helper/release_processor.py
@@ -183,7 +183,8 @@ class quay_controller:
             sys.exit(1)
 
     def get_git_labels(self, repo, tag):
-        url = f'{BASE_URL}/repository/{self.org}/{repo}/manifest/{tag}/labels?filter=git'
+        url = f'{BASE_URL}/repository/{self.org}/{repo}/manifest/{tag}/labels'
+        # ?filter=git, throwing 403 forbidden, due to this need to check, seems quay issue, disabling the fitler for now
         headers = {'Authorization': f'Bearer {os.environ[self.org.upper() + "_QUAY_API_TOKEN"]}',
                    'Accept': 'application/json'}
         response = requests.get(url, headers=headers)

--- a/utils/stage-promoter/requirements.txt
+++ b/utils/stage-promoter/requirements.txt
@@ -3,3 +3,4 @@ jsonpath-ng==1.6.1
 pyyaml==6.0.2
 ruamel.yaml<=0.17.21
 requests==2.31.0
+openshift-client==2.0.5

--- a/utils/stage-promoter/stage_promoter.py
+++ b/utils/stage-promoter/stage_promoter.py
@@ -1,12 +1,14 @@
 import os, requests
 import time
-
+import openshift_client as oc
 from jsonupdate_ng import jsonupdate_ng
 import argparse
 import yaml
 import ruamel.yaml as ruyaml
 import json
 from collections import defaultdict
+from openshift_client.model import OpenShiftPythonException
+
 from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 import base64
 import sys
@@ -101,7 +103,7 @@ class snapshot_processor:
     GIT_COMMIT_LABEL_KEY = 'git.commit'
     FBC_FRAGMENT_REPO = 'rhoai-fbc-fragment'
     QUAY_BASE_URI = 'quay.io/rhoai'
-    def __init__(self, rhoai_version:str, build_config_path:str, timeout:str, output_file_path:str, git_commit:str):
+    def __init__(self, rhoai_version:str, build_config_path:str, timeout:str, output_file_path:str, git_commit:str, pipelineruns:str, pipeline_type:str, failed_pipelines_info_path:str):
         self.output_file_path = output_file_path
         self.rhoai_version = rhoai_version
         self.build_config_path = build_config_path
@@ -109,11 +111,105 @@ class snapshot_processor:
         self.ocp_versions_for_release = self.build_config['config']['supported-ocp-versions']['release']
         self.timeout = int(timeout) * 60
         self.git_commit = git_commit
+        self.pipelineruns = pipelineruns.split(' ')
+        self.pipeline_type = pipeline_type
+        self.failed_pipelines_info_path = failed_pipelines_info_path
+        if os.path.exists(self.failed_pipelines_info_path):
+            os.remove(self.failed_pipelines_info_path)
+        self.slack_failure_message_path = 'utils/slack_failure_message.txt'
+        if os.path.exists(self.slack_failure_message_path):
+            os.remove(self.slack_failure_message_path)
+
+    def monitor_fbc_pipelines(self):
+        print('OpenShift client version: {}'.format(oc.get_client_version()))
+        type = self.pipeline_type
+
+        pipeline_base_url = 'https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns'
+        workspace = 'rhoai' if type == 'build' else 'rhtap-releng' if type == 'release' else ''
+        project = 'rhoai-tenant' if type == 'build' else 'rhtap-releng-tenant' if type == 'release' else ''
+
+        completed_pipelines = {}
+        failed_pipelines = {}
+        unknown_pipelines = {}
+
+        running_statuses = ['Running', 'ResolvingTaskRef']
+        success_statuses = ['Succeeded', 'Completed']
+        failed_statuses = ['Failed', 'PipelineRunTimeout', 'PipelineValidationFailed', 'CreateRunFailed', 'CouldntGetTask', 'ReasonCouldntCreateOrUpdateAffinityAssistantStatefulSet', 'CancelledRunningFinally']
+        unknown_status = ['Unknown']
+
+        with oc.project(project), oc.timeout(180 * 60):
+
+            while len(failed_pipelines) + len(completed_pipelines) < len(self.pipelineruns):
+                for pr in self.pipelineruns:
+                    if pr in failed_pipelines:
+                        print(f'FBC stage {type} pipeline {pr} failed with status {failed_pipelines[pr]["status"]}..')
+                    elif pr in completed_pipelines:
+                        print(
+                            f'FBC stage {type} pipeline {pr} is successfully completed with status {completed_pipelines[pr]["status"]}..')
+                    else:
+                        try:
+                            pr_object = oc.selector(f'pr/{pr}').object()
+                            status = pr_object.model.status.conditions[0].reason
+                        except OpenShiftPythonException as e:
+                            status = 'Unknown'
+                            print(e)
+
+                        print(pr, status)
+                        if status in running_statuses:
+                            print(f'FBC stage {type} pipeline {pr} is still running..')
+                        elif status in success_statuses:
+                            print(f'FBC stage {type} pipeline {pr} is successfully completed with status {status}..')
+                            completed_pipelines[pr] = {'status': status,
+                                                    'application': pr_object.model.metadata.labels[
+                                                        'appstudio.openshift.io/application']}
+                        #elif status in failed_statuses:
+                        else:
+                            print(f'FBC stage {type} pipeline {pr} failed with status {status}..')
+                            failed_pipelines[pr] = {'status': status,
+                                                    'message': pr_object.model.status.conditions[0].message,
+                                                    'application': pr_object.model.metadata.labels[
+                                                        'appstudio.openshift.io/application']}
+                time.sleep(1 * 15)
+
+            if len(failed_pipelines):
+                yaml.safe_dump({'failed_pipelines': list(failed_pipelines.keys())}, open(self.failed_pipelines_info_path, 'w'))
+                slack_failure_message = f':alert: Following stage {type} pipeline(s) failed for {self.rhoai_version}, please check the logs:'
+                print('\n================ FAILURE SUMMARY ================')
+                for pr, data in failed_pipelines.items():
+                    print(f'****** PipelineRun - {pr} ******')
+                    pipeline_url = f'{pipeline_base_url}/{project}/applications/{data["application"]}/pipelineruns/{pr}/logs'
+                    print(f'FBC stage {type} pipeline {pr} failed with status {data["status"]}')
+                    print(f'Error: {data["message"]}')
+                    print(f'Please check full logs at {pipeline_url}')
+                    print('\n')
+                    slack_failure_message += f'\n* <{pipeline_url}|{pr}>: {data["message"]}'
+                open(self.slack_failure_message_path, 'w').write(slack_failure_message)
+            else:
+                print(f'All the FBC stage {type} pipelines are successfully completed!!')
+                if type == 'build':
+                    slack_message = f':staging-green: Successfully pushed *{self.rhoai_version} to stage*!'
+                    qc = quay_controller('rhoai')
+                    fbc_images = {}
+                    for ocp_version in self.ocp_versions_for_release:
+                        fbc_image_tag = f'ocp-{ocp_version.strip("v")}-{self.rhoai_version}-{self.git_commit}'
+                        print(f'getting images for tag - {fbc_image_tag}')
+                        tags = qc.get_all_tags(self.FBC_FRAGMENT_REPO, fbc_image_tag)
+                        for tag in tags:
+                            sig_tag = f'{tag["manifest_digest"].replace(":", "-")}.sig'
+                            signature = qc.get_tag_details(self.FBC_FRAGMENT_REPO, sig_tag)
+                            if signature:
+                                fbc_image = f'{self.QUAY_BASE_URI}/{self.FBC_FRAGMENT_REPO}@{tag["manifest_digest"]}'
+                                fbc_images[ocp_version] = fbc_image
+                                slack_message += f'\n• FBCF image {ocp_version}: {fbc_image}'
+
+                    json.dump(fbc_images, open(self.output_file_path, 'w'))
+                    open('utils/slack_message.txt', 'w').write(slack_message)
 
     def monitor_fbc_builds(self):
         fbc_images = {}
         qc = quay_controller('rhoai')
         time_lapsed = 0
+        delay_sec = 30
         def all_fbc_builds_finished():
             all_versions_covered = True
             for ocp_version in self.ocp_versions_for_release:
@@ -134,9 +230,9 @@ class snapshot_processor:
                     signature = qc.get_tag_details(self.FBC_FRAGMENT_REPO, sig_tag)
                     if signature:
                         fbc_images[ocp_version] = f'{self.QUAY_BASE_URI}/{self.FBC_FRAGMENT_REPO}@{tag["manifest_digest"]}'
-            time.sleep(45)
-            time_lapsed += 60
-            print("time_lapsed - ", str(60), " sec")
+            time.sleep(delay_sec)
+            time_lapsed += delay_sec
+            print("time_lapsed - ", str(delay_sec), " sec")
 
         missing_images = []
         for ocp_version in self.ocp_versions_for_release:
@@ -194,6 +290,64 @@ class quay_controller:
             print(response.json())
             sys.exit(1)
 
+class prereqs_checker:
+    def __init__(self, rhoai_version:str, build_type:str, conforma_results_file_path:str, smokes_results_file_path:str):
+        self.rhoai_version = rhoai_version
+        self.build_type = build_type
+        self.slack_failure_message_path = 'utils/slack_failure_message.txt'
+        if os.path.exists(self.slack_failure_message_path):
+            os.remove(self.slack_failure_message_path)
+
+        self.conforma_results_file_path = conforma_results_file_path
+        self.conforma_results = yaml.safe_load(open(self.conforma_results_file_path))
+
+        self.smokes_results_file_path = smokes_results_file_path
+        self.smokes_results = yaml.safe_load(open(self.smokes_results_file_path))
+
+        self.smokes_tolerance_percentage = 25
+        self.slack_failure_message = f':alert: {self.build_type} stage push failed for *{self.rhoai_version}* due to unsuccessful prerequisites checks:'
+        self.cfr_repo_url = f'https://github.com/red-hat-data-services/conforma-reporter/tree/{self.rhoai_version}'
+
+    def check_prerequisites_status(self):
+        conforma_green = self.check_conforma_status()
+        smokes_green = self.check_smokes_status()
+
+        if not conforma_green or not smokes_green:
+            open(self.slack_failure_message_path, 'w').write(self.slack_failure_message)
+        else:
+            print('All prerequisite checks are successful, moving ahead with the stage push.. ')
+
+    def check_conforma_status(self):
+        print('Checking conforma results..')
+        component_errors = int(self.conforma_results['summary']['component_violations'])
+        fbc_errors = int(self.conforma_results['summary']['fbc_violations'])
+        print(f'Found {component_errors} conforma violations for components and {fbc_errors} conforma violations for FBC fragment')
+        if component_errors > 0:
+            self.slack_failure_message += f'\n• Conforma validation failed for *components*, check more details at <{self.cfr_repo_url}/components-violations.md|Components-Conforma-Violations>'
+            print(f'Conforma validation failed for components, check more details at {self.cfr_repo_url}/components-violations.md')
+        if fbc_errors > 0:
+            self.slack_failure_message += f'\n• Conforma validation failed for *FBC*, check more details at <{self.cfr_repo_url}/fbc-violations.md|FBC-Conforma-Violations>'
+            print(f'Conforma validation failed for FBC, check more details at {self.cfr_repo_url}/fbc-violations.md')
+
+        success = component_errors == 0 and fbc_errors == 0
+        return success
+
+
+    def check_smokes_status(self):
+        print('Checking smoke results..')
+        total_tests = int(self.smokes_results['test_summary']['Total'])
+        failed_tests = int(self.smokes_results['test_summary']['Failed'])
+        print(f'Found {failed_tests} test failures out of total {total_tests} tests executed')
+        success = failed_tests <= total_tests * (self.smokes_tolerance_percentage/100)
+
+        if not success:
+            self.slack_failure_message += f'\n• More than {self.smokes_tolerance_percentage}% smoke tests failed, check more details at <{self.cfr_repo_url}/smoke_test_report.html|Smoke-Test-Report>'
+            print(f'More than {self.smokes_tolerance_percentage}% smoke tests failed, check more details at {self.cfr_repo_url}/smoke_test_report.html')
+        return success
+
+
+
+
 def str_presenter(dumper, data):
     if data.count('\n') > 0:
         return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='|')
@@ -204,7 +358,7 @@ def str_presenter(dumper, data):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-op', '--operation', required=False,
-                        help='Operation code, supported values are "stage-catalog-patch" and "monitor-fbc-builds"', dest='operation')
+                        help='Operation code, supported values are "stage-catalog-patch", "monitor-fbc-builds", "monitor-fbc-pipelines" and "check-prerequisite-status"', dest='operation')
     parser.add_argument('-c', '--catalog-yaml-path', required=False,
                         help='Path of the catalog.yaml from the main branch.', dest='catalog_yaml_path')
     parser.add_argument('-p', '--patch-yaml-path', required=False,
@@ -221,6 +375,12 @@ if __name__ == '__main__':
                         help='Path of the build-config.yaml', dest='build_config_path')
     parser.add_argument('-g', '--git-commit', required=False,
                         help='expected git.commit of the FBC images', dest='git_commit')
+    parser.add_argument('-prs', '--pipelineruns', required=False, default='', dest='pipelineruns')
+    parser.add_argument('-pt', '--pipeline-type', required=False, default='', dest='pipeline_type')
+    parser.add_argument('-fp', '--failed-pipelines-info-path', required=False, default='', dest='failed_pipelines_info_path')
+    parser.add_argument('-cfr', '--conforma-results-file-path', required=False, default='', dest='conforma_results_file_path')
+    parser.add_argument('-smr', '--smokes-results-file-path', required=False, default='', dest='smokes_results_file_path')
+    parser.add_argument('-bt', '--build-type', required=False, default='nightly', dest='build_type')
     args = parser.parse_args()
 
     if args.operation.lower() == 'stage-catalog-patch':
@@ -229,6 +389,12 @@ if __name__ == '__main__':
     elif args.operation.lower() == 'monitor-fbc-builds':
         processor = snapshot_processor(rhoai_version=args.rhoai_version, build_config_path=args.build_config_path, timeout=args.timeout, output_file_path=args.output_file_path, git_commit=args.git_commit)
         processor.monitor_fbc_builds()
+    elif args.operation.lower() == 'monitor-fbc-pipelines':
+        processor = snapshot_processor(rhoai_version=args.rhoai_version, build_config_path=args.build_config_path, timeout=args.timeout, output_file_path=args.output_file_path, git_commit=args.git_commit, pipelineruns=args.pipelineruns, pipeline_type=args.pipeline_type, failed_pipelines_info_path=args.failed_pipelines_info_path)
+        processor.monitor_fbc_pipelines()
+    elif args.operation.lower() == 'check-prerequisite-status':
+        checker = prereqs_checker(rhoai_version=args.rhoai_version, build_type=args.build_type, conforma_results_file_path=args.conforma_results_file_path, smokes_results_file_path=args.smokes_results_file_path)
+        checker.check_prerequisites_status()
 
 
 

--- a/utils/stage-promoter/stage_promoter.py
+++ b/utils/stage-promoter/stage_promoter.py
@@ -279,7 +279,8 @@ class quay_controller:
         return tag
 
     def get_git_labels(self, repo, tag):
-        url = f'{BASE_URL}/repository/{self.org}/{repo}/manifest/{tag}/labels?filter=git'
+        url = f'{BASE_URL}/repository/{self.org}/{repo}/manifest/{tag}/labels'
+        # ?filter=git, throwing 403 forbidden, due to this need to check, seems quay issue, disabling the fitler for now
         headers = {'Authorization': f'Bearer {os.environ[self.org.upper() + "_QUAY_API_TOKEN"]}',
                    'Accept': 'application/json'}
         response = requests.get(url, headers=headers)

--- a/utils/stage-promoter/stage_promoter.py
+++ b/utils/stage-promoter/stage_promoter.py
@@ -387,7 +387,7 @@ if __name__ == '__main__':
         promoter = stage_promoter(catalog_yaml_path=args.catalog_yaml_path, patch_yaml_path=args.patch_yaml_path, release_catalog_yaml_path=args.release_catalog_yaml_path, output_file_path=args.output_file_path, rhoai_version=args.rhoai_version)
         promoter.patch_catalog_yaml()
     elif args.operation.lower() == 'monitor-fbc-builds':
-        processor = snapshot_processor(rhoai_version=args.rhoai_version, build_config_path=args.build_config_path, timeout=args.timeout, output_file_path=args.output_file_path, git_commit=args.git_commit)
+        processor = snapshot_processor(rhoai_version=args.rhoai_version, build_config_path=args.build_config_path, timeout=args.timeout, output_file_path=args.output_file_path, git_commit=args.git_commit, pipelineruns=args.pipelineruns, pipeline_type=args.pipeline_type, failed_pipelines_info_path=args.failed_pipelines_info_path)
         processor.monitor_fbc_builds()
     elif args.operation.lower() == 'monitor-fbc-pipelines':
         processor = snapshot_processor(rhoai_version=args.rhoai_version, build_config_path=args.build_config_path, timeout=args.timeout, output_file_path=args.output_file_path, git_commit=args.git_commit, pipelineruns=args.pipelineruns, pipeline_type=args.pipeline_type, failed_pipelines_info_path=args.failed_pipelines_info_path)

--- a/utils/stage-promoter/stage_promoter.py
+++ b/utils/stage-promoter/stage_promoter.py
@@ -1,4 +1,6 @@
-import os, requests
+import os
+import re
+import requests
 import time
 import openshift_client as oc
 from jsonupdate_ng import jsonupdate_ng
@@ -13,9 +15,14 @@ from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 import base64
 import sys
 
+
 class stage_promoter:
     PRODUCTION_REGISTRY = 'registry.redhat.io'
     PACKAGE_NAME = 'rhods-operator'
+    # Channel names that are reset from patch (no merge with base catalog).
+    RESET_CHANNELS = {'alpha'}
+    # Version after PACKAGE_NAME.: X.Y.Z-ea.N or X.Y.Z-ea.N.H (H optional). X=0-9, Y/Z=0-99.
+    EA_VERSION_PATTERN = re.compile(r"^[0-9]\.[0-9]{1,2}\.[0-9]{1,2}-ea\.[0-9]+(\.[0-9]+)?$")
 
     def __init__(self, catalog_yaml_path:str, patch_yaml_path:str, release_catalog_yaml_path:str, output_file_path:str, rhoai_version:str):
         self.catalog_yaml_path = catalog_yaml_path
@@ -89,14 +96,84 @@ class stage_promoter:
         SCHEMA = 'olm.channel'
         PATCH_SCHEMA = 'olm.channels'
         for channel in self.patch_dict['patch'][PATCH_SCHEMA]:
-            if channel['name'] in self.catalog_dict[SCHEMA]:
+            if channel['name'] in self.catalog_dict[SCHEMA] and channel['name'] not in self.RESET_CHANNELS:
                 self.catalog_dict[SCHEMA][channel['name']] = jsonupdate_ng.updateJson(self.catalog_dict[SCHEMA][channel['name']], channel, meta={'listPatchScheme': {'$.entries': {'key': 'name'}}})
             else:
+                # If reset channel or new channel, take full definition from patch.
                 self.catalog_dict[SCHEMA][channel['name']] = channel
 
+        # Keep only the latest EA drop in the alpha channel to support fresh install only.
+        if 'alpha' in self.catalog_dict[SCHEMA]:
+            self.prune_channel_to_latest_ea(SCHEMA, 'alpha')
+
+    # updates a given OLM channel so that only the latest Early Access (EA) version remains in entries.
+    def prune_channel_to_latest_ea(self, schema, channel_name):
+        channel = self.catalog_dict[schema][channel_name]
+        entries = [e for e in (channel.get('entries') or []) if e.get('name')]
+        ea = [e for e in entries if 'ea' in (e.get('name') or '')]
+        if not ea:
+            raise ValueError(f"Channel {channel_name!r} has no EA versions.")
+        # How largest is decided: key = (release, ea_segments). Tuples compared left-to-right (lexicographic).
+        # Example keys:
+        #   3.4.0-ea.1   -> ((3, 4, 0), (1,))
+        #   3.4.0-ea.1.1 -> ((3, 4, 0), (1, 1))
+        #   3.14.0-ea.2  -> ((3, 14, 0), (2,))
+        # Step 1: compare release; (3,4,0) < (3,14,0) so 3.14.0-ea.2 wins over 3.4.0-ea.*.
+        # Step 2: if release equal, compare ea_segments; (1,) < (1,1) so ea.1.1 > ea.1. max() picks entry with largest key.
+        latest_ea_entry = max(ea, key=lambda e: self.parse_ea_entry_name(e['name']))
+        channel['entries'] = [{'name': latest_ea_entry['name']}]
+
+    def parse_ea_entry_name(self, entry_name: str):
+        """
+        Parse EA OLM entry name into a comparable tuple for ordering. Raises ValueError if invalid.
+
+        entry_name must be in the below format:
+        - rhods-operator.X.Y.Z-ea.N
+        - rhods-operator.X.Y.Z-ea.N.H
+        X = 0-9, Y/Z = 0-99, N/H = non-negative integers.
+
+        Returns:
+            (release, ea_segments): Comparable tuple for ordering. Example:
+                parse_ea_entry_name("rhods-operator.3.4.0-ea.1.1") -> ((3, 4, 0), (1, 1))
+        """
+        entry_name = entry_name.strip()
+        prefix = self.PACKAGE_NAME + "."
+        version_str = entry_name[len(prefix):] if entry_name.startswith(prefix) else ""
+        if not version_str or not self.EA_VERSION_PATTERN.match(version_str):
+            raise ValueError(
+                f"Invalid EA version for entry {entry_name!r}: must be {prefix!r} followed by "
+                "X.Y.Z-ea.N or X.Y.Z-ea.N.H (e.g. 3.4.0-ea.1, 3.4.0-ea.1.1)"
+            )
+        s = version_str
+        base, _, suffix = s.partition("-ea")
+        base = base.strip(".-")
+        suffix = suffix.strip(".")
+        try:
+            parts = [x for x in base.split(".") if x]
+            if len(parts) != 3:
+                raise ValueError(f"Release must be exactly X.Y.Z, got {base!r}")
+            release = tuple(int(x) for x in parts)
+            x_val, y_val, z_val = release
+            if not (0 <= x_val <= 9):
+                raise ValueError(f"X must be 0-9, got {x_val}")
+            if not (0 <= y_val <= 99 and 0 <= z_val <= 99):
+                raise ValueError(f"Y and Z must be 0-99, got {y_val}, {z_val}")
+        except ValueError as err:
+            raise ValueError(f"Invalid EA version for entry {entry_name!r}: {err}") from err
+        if not suffix:
+            ea_segments = (0,)
+        else:
+            try:
+                ea_segments = tuple(int(x) for x in suffix.split(".") if x)
+            except ValueError as err:
+                raise ValueError(f"Invalid EA version for entry {entry_name!r}: {err}") from err
+            if not ea_segments:
+                ea_segments = (0,)
+        return (release, ea_segments)
 
     def patch_olm_bundles(self):
         return self.patch_current_release_bundle_schema()
+
 
 class snapshot_processor:
     GIT_URL_LABEL_KEY = 'git.url'

--- a/utils/stage-promoter/stage_promoter.py
+++ b/utils/stage-promoter/stage_promoter.py
@@ -112,8 +112,7 @@ class stage_promoter:
         entries = [e for e in (channel.get('entries') or []) if e.get('name')]
         ea = [e for e in entries if 'ea' in (e.get('name') or '')]
         if not ea:
-            print(f"Channel {channel_name!r} has no EA versions, skipping pruning.")
-            return
+            raise ValueError(f"Channel {channel_name!r} has no EA versions.")
         # How largest is decided: key = (release, ea_segments). Tuples compared left-to-right (lexicographic).
         # Example keys:
         #   3.4.0-ea.1   -> ((3, 4, 0), (1,))

--- a/utils/stage-promoter/stage_promoter.py
+++ b/utils/stage-promoter/stage_promoter.py
@@ -15,6 +15,21 @@ from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 import base64
 import sys
 
+class OpenshiftVersion(tuple):
+    def __new__(cls, version_str):
+        regex = re.match(r'v(\d+)\.(\d+)', version_str)
+        if not regex:
+            regex = re.match(r'(\d+)\.(\d+)', version_str)
+            if not regex:
+                raise ValueError(f"Was not able to parse {version_str}")
+
+        x = regex.group(1)
+        y = regex.group(2)
+
+        return super().__new__(cls, (int(x), int(y)))
+
+    def __init__(self, version_str):
+        self.version = version_str
 
 class stage_promoter:
     PRODUCTION_REGISTRY = 'registry.redhat.io'
@@ -26,6 +41,13 @@ class stage_promoter:
 
     def __init__(self, catalog_yaml_path:str, patch_yaml_path:str, release_catalog_yaml_path:str, output_file_path:str, rhoai_version:str):
         self.catalog_yaml_path = catalog_yaml_path
+
+        # a hack to get the ocp version
+        ocp_regex = re.search(r'catalog-(.*?)\.yaml', catalog_yaml_path)
+        if not ocp_regex:
+            raise ValueError(f"was not able to parse OCP version from catalog path: {catalog_yaml_path}")
+
+        self.ocp_version = ocp_regex.group(1)
         self.patch_yaml_path = patch_yaml_path
         self.release_catalog_yaml_path = release_catalog_yaml_path
         self.output_file_path = output_file_path
@@ -102,8 +124,11 @@ class stage_promoter:
                 # If reset channel or new channel, take full definition from patch.
                 self.catalog_dict[SCHEMA][channel['name']] = channel
 
+        # if ocp v4.19+ is supported, then we expect the beta channel to exist and follow ea drop scheme
+        supports_ea_drops = OpenshiftVersion(self.ocp_version) >= OpenshiftVersion('v4.19')
+
         # Keep only the latest EA drop in the beta channel to support fresh install only.
-        if 'beta' in self.catalog_dict[SCHEMA]:
+        if 'beta' in self.catalog_dict[SCHEMA] and supports_ea_drops:
             self.prune_channel_to_latest_ea(SCHEMA, 'beta')
 
     # updates a given OLM channel so that only the latest Early Access (EA) version remains in entries.

--- a/utils/stage-promoter/stage_promoter.py
+++ b/utils/stage-promoter/stage_promoter.py
@@ -112,7 +112,8 @@ class stage_promoter:
         entries = [e for e in (channel.get('entries') or []) if e.get('name')]
         ea = [e for e in entries if 'ea' in (e.get('name') or '')]
         if not ea:
-            raise ValueError(f"Channel {channel_name!r} has no EA versions.")
+            print(f"Channel {channel_name!r} has no EA versions, skipping pruning.")
+            return
         # How largest is decided: key = (release, ea_segments). Tuples compared left-to-right (lexicographic).
         # Example keys:
         #   3.4.0-ea.1   -> ((3, 4, 0), (1,))

--- a/utils/stage-promoter/stage_promoter.py
+++ b/utils/stage-promoter/stage_promoter.py
@@ -20,7 +20,7 @@ class stage_promoter:
     PRODUCTION_REGISTRY = 'registry.redhat.io'
     PACKAGE_NAME = 'rhods-operator'
     # Channel names that are reset from patch (no merge with base catalog).
-    RESET_CHANNELS = {'alpha'}
+    RESET_CHANNELS = {'beta'}
     # Version after PACKAGE_NAME.: X.Y.Z-ea.N or X.Y.Z-ea.N.H (H optional). X=0-9, Y/Z=0-99.
     EA_VERSION_PATTERN = re.compile(r"^[0-9]\.[0-9]{1,2}\.[0-9]{1,2}-ea\.[0-9]+(\.[0-9]+)?$")
 
@@ -102,9 +102,9 @@ class stage_promoter:
                 # If reset channel or new channel, take full definition from patch.
                 self.catalog_dict[SCHEMA][channel['name']] = channel
 
-        # Keep only the latest EA drop in the alpha channel to support fresh install only.
-        if 'alpha' in self.catalog_dict[SCHEMA]:
-            self.prune_channel_to_latest_ea(SCHEMA, 'alpha')
+        # Keep only the latest EA drop in the beta channel to support fresh install only.
+        if 'beta' in self.catalog_dict[SCHEMA]:
+            self.prune_channel_to_latest_ea(SCHEMA, 'beta')
 
     # updates a given OLM channel so that only the latest Early Access (EA) version remains in entries.
     def prune_channel_to_latest_ea(self, schema, channel_name):

--- a/utils/validators/bootstrap.sh
+++ b/utils/validators/bootstrap.sh
@@ -35,7 +35,7 @@ PCC_FOLDER_PATH=main/pcc
 GLOBAL_CONFIG_PATH=main/config/config.yaml
 
 echo PCC Cache Validation
-# python3 ./catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ${GLOBAL_CONFIG_PATH}
+python3 ./catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ${GLOBAL_CONFIG_PATH}
 
 BUILD_CONFIG_PATH=${BRANCH}/config/build-config.yaml
 SHIPPED_RHOAI_VERSIONS_PATH=main/pcc/shipped_rhoai_versions_granular.txt

--- a/utils/validators/bootstrap.sh
+++ b/utils/validators/bootstrap.sh
@@ -1,0 +1,47 @@
+# Usage
+#
+# export BRANCH variables before running this 
+#  script as required.
+#
+#    export BRANCH=rhoai-3.4-ea.2
+#    ./bootstrap.sh
+# 
+# run ./bootstrap.sh --pull-repos if you want to re-pull RHOAI-Build-Config.
+
+set -eo pipefail
+
+BRANCH=${BRANCH:-rhoai-3.4-ea.2}
+
+
+if [[ "$1" == "--pull-repos"  || ! -d main || ! -d "${BRANCH}" ]]; then
+  rm -rf "${BRANCH}" main
+  git init main
+  git -C main remote add origin https://github.com/red-hat-data-services/RHOAI-Build-Config.git 
+
+  # shallow fetch, use `git fetch --unshallow` to get full fetch`
+  git -C main fetch origin --depth=1 main "${BRANCH}" 
+  git -C main checkout main
+  git -C main worktree add ../"${BRANCH}" origin/"${BRANCH}"
+fi
+
+function python3 () {
+  uv run $@
+}
+
+PCC_FOLDER_PATH=main/pcc
+BUILD_CONFIG_PATH=main/config/config.yaml
+SHIPPED_RHOAI_VERSIONS_PATH=main/pcc/shipped_rhoai_versions_granular.txt
+PCC_FOLDER_PATH=main/pcc
+GLOBAL_CONFIG_PATH=main/config/config.yaml
+
+echo PCC Cache Validation
+# python3 ./catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ${GLOBAL_CONFIG_PATH}
+
+BUILD_CONFIG_PATH=${BRANCH}/config/build-config.yaml
+SHIPPED_RHOAI_VERSIONS_PATH=main/pcc/shipped_rhoai_versions_granular.txt
+CATALOG_FOLDER_PATH=${BRANCH}/catalog
+GLOBAL_CONFIG_PATH=main/config/config.yaml
+
+echo Running Catalog Validation
+python3 ./catalog_validator.py -op validate-catalogs --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${CATALOG_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ${GLOBAL_CONFIG_PATH}
+

--- a/utils/validators/catalog_validator.py
+++ b/utils/validators/catalog_validator.py
@@ -60,7 +60,7 @@ class catalog_validator:
                 if operator_name not in bundles and operator_name not in self.MISSING_BUNDLE_EXCEPTIONS:
                     if not (rhoai_version.startswith(
                             'v3') and numeric_ocp_version < self.MIN_OCP_VERSION_FOR_RHOAI_30):  # bypassing check for 3.0 for OCP < 4.19
-                        print(f"Skipping the catalog validation for {rhoai_version} bundle for OCP {ocp_version}, since 3.x is not shipped on these OCP versions!")
+                        print(f"Skipping the catalog validation for {rhoai_version} bundle for OCP {ocp_version}, since 3.x is not shipped on this OCP version!")
                         continue
                     missing_bundles[ocp_version].append(operator_name)
 

--- a/utils/validators/catalog_validator.py
+++ b/utils/validators/catalog_validator.py
@@ -60,7 +60,9 @@ class catalog_validator:
                 if operator_name not in bundles and operator_name not in self.MISSING_BUNDLE_EXCEPTIONS:
                     if not (rhoai_version.startswith(
                             'v3') and numeric_ocp_version < self.MIN_OCP_VERSION_FOR_RHOAI_30):  # bypassing check for 3.0 for OCP < 4.19
-                        missing_bundles[ocp_version].append(operator_name)
+                        print(f"Skipping the catalog validation for {rhoai_version} bundle for OCP {ocp_version}, since 3.x is not shipped on these OCP versions!")
+                        continue
+                    missing_bundles[ocp_version].append(operator_name)
 
                 if operator_name in bundles and rhoai_version.startswith('v3') and numeric_ocp_version < self.MIN_OCP_VERSION_FOR_RHOAI_30: # adding check to ensure 3.x doesn't land on OCP < 4.19
                     incorrect_3x_bundles[ocp_version].append(operator_name)

--- a/utils/validators/catalog_validator.py
+++ b/utils/validators/catalog_validator.py
@@ -68,27 +68,33 @@ class catalog_validator:
         def __lt__(self, other):
             return self._parsed_tuple < other._parsed_tuple
 
+        def __eq__(self, other):
+            return self._parsed_tuple == other._parsed_tuple
+
         def __getitem__(self, key):
             return self._parsed_tuple[key]
 
         def __repr__(self):
             return self.version
 
-        # given a list of versions, determine if this is the latest ea version for a given (major, minor, patch)
+        # given a list of versions, determine if this is the globally latest ea version 
         def is_latest_ea(self, versions_list):
-            latest = self._parsed_tuple
+            latest = self
+
             for item in versions_list:
+                # This try block filters out all the legacy releases that don't match 
+                #  the expected pattern
                 try: 
                     version = self.__class__(item) 
                 except ValueError:
                     continue
                 else:
-                    if version[0:4] != latest[0:4]:
-                        continue
-                    if version[4:] > latest[4:]:
+                    # Check if greater, but skip if GA release
+                    if version >= latest and version[3] == 0:
                         latest = version
-            print(f"{latest} is the newest version in the vicinity of {self.version}")
-            return latest == self._parsed_tuple
+
+            print(f"{latest} is the newest EA release")
+            return latest == self
             
     def __init__(self, build_config_path, catalog_folder_path, shipped_rhoai_versions_path, operation, global_config_path):
         self.build_config_path = build_config_path

--- a/utils/validators/catalog_validator.py
+++ b/utils/validators/catalog_validator.py
@@ -62,7 +62,7 @@ class catalog_validator:
         def __le__(self, other):
             return self._parsed_tuple <= other._parsed_tuple
 
-    def __init__(self, build_config_path, catalog_folder_path, shipped_rhoai_versions_path, operation):
+    def __init__(self, build_config_path, catalog_folder_path, shipped_rhoai_versions_path, operation, global_config_path):
         self.build_config_path = build_config_path
         self.catalog_folder_path = catalog_folder_path
         self.shipped_rhoai_versions_path = shipped_rhoai_versions_path
@@ -72,6 +72,11 @@ class catalog_validator:
         self.build_config = yaml.safe_load(open(self.build_config_path))
         self.supported_ocp_versions = sorted(list(set(self.build_config['config']['supported-ocp-versions']['release'] + [item['name'] for item in self.build_config['config']['supported-ocp-versions']['build']]))) if operation == 'validate-catalogs' \
             else sorted(self.build_config['config']['supported-ocp-versions'], key=lambda x: x['version']) if operation == 'validate-pcc' else None
+
+        self.global_config = yaml.safe_load(open(global_config_path))
+        global_ocp_versions = self.global_config['config']['supported-ocp-versions']
+        self.discontinuity_map = {entry['version']: entry['discontinued-from'] if 'discontinued-from' in entry else 'rhods-operator.9.99.99' for entry in global_ocp_versions}
+        self.onboarding_map = {entry['version']: entry['onboarded-since'] if 'onboarded-since' in entry else 'rhods-operator.0.0.0' for entry in global_ocp_versions}
 
         self.shipped_rhoai_versions = open(self.shipped_rhoai_versions_path).readlines()
 
@@ -94,7 +99,7 @@ class catalog_validator:
     def validate_catalogs(self):
         missing_bundles = {}
         incorrect_3x_bundles = {}
-        # need to get the global config.yaml and process the discontinuity map in order to ignore the unsupported OCP versions like 4.14, same as what was done for pcc validation
+
         for ocp_version in self.supported_ocp_versions:
             catalog_dict = self.parse_catalog_yaml(f'{self.catalog_folder_path}/{ocp_version}/rhods-operator/catalog.yaml')
             bundles = catalog_dict['olm.bundle']
@@ -113,7 +118,10 @@ class catalog_validator:
                     if is_3x_on_unsupported_ocp:
                         print(f"Skipping the catalog validation for {rhoai_version} bundle for OCP {ocp_version}, since 3.x is not shipped on this OCP version!")
                         continue
-                    missing_bundles[ocp_version].append(operator_name)
+                    if not self.rhods_operator(operator_name) >= self.rhods_operator(self.discontinuity_map[ocp_version]) and not self.rhods_operator(operator_name) <= self.rhods_operator(self.onboarding_map[ocp_version]):
+                        missing_bundles[ocp_version].append(operator_name)
+                    else:
+                        print(f'Ignoring since OCP {ocp_version} is not supported for {operator_name}')
 
                 if operator_name in bundles and is_3x_on_unsupported_ocp:
                     incorrect_3x_bundles[ocp_version].append(operator_name)
@@ -142,8 +150,6 @@ class catalog_validator:
 
     def validate_pcc(self):
         missing_bundles = {}
-        discontinuity_map = {ocp_version['version']:ocp_version['discontinued-from'] if 'discontinued-from' in ocp_version else 'rhods-operator.9.99.99' for ocp_version in self.supported_ocp_versions }
-        onboarding_map = {ocp_version['version']:ocp_version['onboarded-since'] if 'onboarded-since' in ocp_version else 'rhods-operator.0.0.0' for ocp_version in self.supported_ocp_versions }
         pcc_catalog_files = [f'catalog-{ocp_version["version"]}.yaml' for ocp_version in
                                   self.supported_ocp_versions]
 
@@ -164,7 +170,7 @@ class catalog_validator:
 
                 if operator_name not in bundles and operator_name not in self.MISSING_BUNDLE_EXCEPTIONS:
                     if not (is_3x_on_unsupported_ocp):
-                        if not self.rhods_operator(operator_name) >= self.rhods_operator(discontinuity_map[ocp_version]) and not self.rhods_operator(operator_name) <= self.rhods_operator(onboarding_map[ocp_version]):
+                        if not self.rhods_operator(operator_name) >= self.rhods_operator(self.discontinuity_map[ocp_version]) and not self.rhods_operator(operator_name) <= self.rhods_operator(self.onboarding_map[ocp_version]):
                             missing_bundles[pcc_file].append(operator_name)
                         else:
                             print(f'Ignoring since OCP {ocp_version} is not supported for {operator_name}')
@@ -191,13 +197,15 @@ if __name__ == '__main__':
                         help='Path of the catalog.yaml from the main branch.', dest='catalog_folder_path')
     parser.add_argument('-s', '--shipped-rhoai-versions-path', required=False,
                         help='Path of the shipped_rhoai_versions.txt from the main branch.', dest='shipped_rhoai_versions_path')
+    parser.add_argument('-g', '--global-config-path', required=True,
+                        help='Path of the global config.yaml (from main branch) containing discontinuity/onboarding maps.', dest='global_config_path')
     args = parser.parse_args()
 
     if args.operation.lower() == 'validate-catalogs':
-        validator = catalog_validator(build_config_path=args.build_config_path, catalog_folder_path=args.catalog_folder_path, shipped_rhoai_versions_path=args.shipped_rhoai_versions_path, operation=args.operation)
+        validator = catalog_validator(build_config_path=args.build_config_path, catalog_folder_path=args.catalog_folder_path, shipped_rhoai_versions_path=args.shipped_rhoai_versions_path, operation=args.operation, global_config_path=args.global_config_path)
         validator.validate_catalogs()
     elif args.operation.lower() == 'validate-pcc':
-        validator = catalog_validator(build_config_path=args.build_config_path, catalog_folder_path=args.catalog_folder_path, shipped_rhoai_versions_path=args.shipped_rhoai_versions_path, operation=args.operation)
+        validator = catalog_validator(build_config_path=args.build_config_path, catalog_folder_path=args.catalog_folder_path, shipped_rhoai_versions_path=args.shipped_rhoai_versions_path, operation=args.operation, global_config_path=args.global_config_path)
         validator.validate_pcc()
 
 

--- a/utils/validators/catalog_validator.py
+++ b/utils/validators/catalog_validator.py
@@ -8,20 +8,59 @@ import re
 class catalog_validator:
     MISSING_BUNDLE_EXCEPTIONS = ['rhods-operator.2.9.0', 'rhods-operator.2.9.1'] #ref - RHOAIENG-8828
     MIN_OCP_VERSION_FOR_RHOAI_30 = 419
+    # Matches both raw image tags (e.g. "v3.4.0-ea.1") and operator bundle names
+    # (e.g. "rhods-operator.3.4.0-ea.1"). The $ anchor rejects build-number tags
+    # (v2.16.0-1733155920) and source tags (v2.16.0-source) since they have
+    # trailing content that doesn't match end-of-string.
+    #
+    # Capture groups:
+    #   1 = full version string  (e.g. "3.4.0-ea.1")
+    #   2 = major, 3 = minor, 4 = patch
+    #   5 = EA sequence number   (None for GA)
+    #   6 = EA hotfix number     (None if no hotfix)
+    VERSION_REGEX = re.compile(
+        r'(?:rhods-operator\.|v?)((\d+)\.(\d+)\.(\d+)(?:-ea\.(\d+)(?:\.(\d+))?)?)$'
+    )
 
     class rhods_operator:
-        def __init__(self, version:str):
+        def __init__(self, version: str):
             self.version = version
+            self._parsed_tuple = self._parse_version(version)
+
+        def _parse_version(self, version_string):
+            """
+            Parse 'rhods-operator.MAJOR.MINOR.PATCH[-ea.SEQ[.HOTFIX]]'
+            into a comparable tuple.
+
+            GA versions get is_ga=1 (sorts higher than EA's is_ga=0),
+            so 3.4.0 (GA) > 3.4.0-ea.N (any EA).
+            """
+            match_result = catalog_validator.VERSION_REGEX.match(version_string)
+            if not match_result:
+                raise ValueError(f"Cannot parse operator version: {version_string}")
+
+            major = int(match_result.group(2))
+            minor = int(match_result.group(3))
+            patch = int(match_result.group(4))
+            ea_sequence = match_result.group(5)
+            ea_hotfix = match_result.group(6)
+
+            if ea_sequence is not None:
+                is_ga = 0
+                ea_sequence_num = int(ea_sequence)
+                ea_hotfix_num = int(ea_hotfix) if ea_hotfix else 0
+            else:
+                is_ga = 1
+                ea_sequence_num = 0
+                ea_hotfix_num = 0
+
+            return (major, minor, patch, is_ga, ea_sequence_num, ea_hotfix_num)
 
         def __ge__(self, other):
-            self.semver = self.version.replace('rhods-operator.', '').split('.')
-            other.semver = other.version.replace('rhods-operator.', '').split('.')
-            return True if self.semver[0] > other.semver[0] else (True if self.semver[1] > other.semver[1] else self.semver[2] >= other.semver[2] if self.semver[1] == other.semver[1] else False) if self.semver[0] == other.semver[0] else False
+            return self._parsed_tuple >= other._parsed_tuple
 
         def __le__(self, other):
-            self.semver = self.version.replace('rhods-operator.', '').split('.')
-            other.semver = other.version.replace('rhods-operator.', '').split('.')
-            return True if self.semver[0] < other.semver[0] else (True if self.semver[1] < other.semver[1] else self.semver[2] <= other.semver[2] if self.semver[1] == other.semver[1] else False) if self.semver[0] == other.semver[0] else False
+            return self._parsed_tuple <= other._parsed_tuple
 
     def __init__(self, build_config_path, catalog_folder_path, shipped_rhoai_versions_path, operation):
         self.build_config_path = build_config_path
@@ -36,9 +75,12 @@ class catalog_validator:
 
         self.shipped_rhoai_versions = open(self.shipped_rhoai_versions_path).readlines()
 
-        self.shipped_rhoai_versions = sorted(list(
-            set([version.split('-')[0].strip('\n').replace('v', '') for version in self.shipped_rhoai_versions if
-                 version.count('.') > 1])))
+        self.shipped_rhoai_versions = sorted(list(set(
+            version_match.group(1)
+            for raw_version in self.shipped_rhoai_versions
+            for version_match in [self.VERSION_REGEX.match(raw_version.strip())]
+            if version_match
+        )))
         print('shipped_rhoai_versions', self.shipped_rhoai_versions)
 
     def parse_catalog_yaml(self, catalog_yaml_path):
@@ -62,14 +104,18 @@ class catalog_validator:
 
             for rhoai_version in self.shipped_rhoai_versions:
                 operator_name = f'rhods-operator.{rhoai_version}'
+                is_3x_on_unsupported_ocp = (
+                    rhoai_version.startswith('3')
+                    and numeric_ocp_version < self.MIN_OCP_VERSION_FOR_RHOAI_30
+                )
+
                 if operator_name not in bundles and operator_name not in self.MISSING_BUNDLE_EXCEPTIONS:
-                    if not (rhoai_version.startswith(
-                            'v3') and numeric_ocp_version < self.MIN_OCP_VERSION_FOR_RHOAI_30):  # bypassing check for 3.0 for OCP < 4.19
+                    if is_3x_on_unsupported_ocp:
                         print(f"Skipping the catalog validation for {rhoai_version} bundle for OCP {ocp_version}, since 3.x is not shipped on this OCP version!")
                         continue
                     missing_bundles[ocp_version].append(operator_name)
 
-                if operator_name in bundles and rhoai_version.startswith('v3') and numeric_ocp_version < self.MIN_OCP_VERSION_FOR_RHOAI_30: # adding check to ensure 3.x doesn't land on OCP < 4.19
+                if operator_name in bundles and is_3x_on_unsupported_ocp:
                     incorrect_3x_bundles[ocp_version].append(operator_name)
 
         print('missing_bundles', missing_bundles)
@@ -111,8 +157,13 @@ class catalog_validator:
 
             for rhoai_version in self.shipped_rhoai_versions:
                 operator_name = f'rhods-operator.{rhoai_version}'
+                is_3x_on_unsupported_ocp = (
+                    rhoai_version.startswith('3')
+                    and numeric_ocp_version < self.MIN_OCP_VERSION_FOR_RHOAI_30
+                )
+
                 if operator_name not in bundles and operator_name not in self.MISSING_BUNDLE_EXCEPTIONS:
-                    if not (rhoai_version.startswith('v3') and numeric_ocp_version < self.MIN_OCP_VERSION_FOR_RHOAI_30): # bypassing check for 3.0 for OCP < 4.19
+                    if not (is_3x_on_unsupported_ocp):
                         if not self.rhods_operator(operator_name) >= self.rhods_operator(discontinuity_map[ocp_version]) and not self.rhods_operator(operator_name) <= self.rhods_operator(onboarding_map[ocp_version]):
                             missing_bundles[pcc_file].append(operator_name)
                         else:

--- a/utils/validators/catalog_validator.py
+++ b/utils/validators/catalog_validator.py
@@ -62,6 +62,12 @@ class catalog_validator:
         def __le__(self, other):
             return self._parsed_tuple <= other._parsed_tuple
 
+        def __gt__(self, other):
+            return self._parsed_tuple > other._parsed_tuple
+
+        def __lt__(self, other):
+            return self._parsed_tuple < other._parsed_tuple
+
     def __init__(self, build_config_path, catalog_folder_path, shipped_rhoai_versions_path, operation, global_config_path):
         self.build_config_path = build_config_path
         self.catalog_folder_path = catalog_folder_path
@@ -114,17 +120,23 @@ class catalog_validator:
                     and numeric_ocp_version < self.MIN_OCP_VERSION_FOR_RHOAI_30
                 )
 
-                if operator_name not in bundles and operator_name not in self.MISSING_BUNDLE_EXCEPTIONS:
+                if operator_name in bundles:
                     if is_3x_on_unsupported_ocp:
-                        print(f"Skipping the catalog validation for {rhoai_version} bundle for OCP {ocp_version}, since 3.x is not shipped on this OCP version!")
-                        continue
-                    if not self.rhods_operator(operator_name) >= self.rhods_operator(self.discontinuity_map[ocp_version]) and not self.rhods_operator(operator_name) <= self.rhods_operator(self.onboarding_map[ocp_version]):
-                        missing_bundles[ocp_version].append(operator_name)
-                    else:
-                        print(f'Ignoring since OCP {ocp_version} is not supported for {operator_name}')
+                        incorrect_3x_bundles[ocp_version].append(operator_name)
+                    continue
 
-                if operator_name in bundles and is_3x_on_unsupported_ocp:
-                    incorrect_3x_bundles[ocp_version].append(operator_name)
+                if operator_name in self.MISSING_BUNDLE_EXCEPTIONS:
+                    continue
+
+                if is_3x_on_unsupported_ocp:
+                    print(f"Skipping the catalog validation for {rhoai_version} bundle for OCP {ocp_version}, since 3.x is not shipped on this OCP version!")
+                    continue
+
+                if self.rhods_operator(operator_name) >= self.rhods_operator(self.discontinuity_map[ocp_version]) \
+                        or self.rhods_operator(operator_name) < self.rhods_operator(self.onboarding_map[ocp_version]):
+                    print(f'Ignoring since OCP {ocp_version} is not supported for {operator_name}')
+                else:
+                    missing_bundles[ocp_version].append(operator_name)
 
         print('missing_bundles', missing_bundles)
         print('incorrect_3x_bundles', incorrect_3x_bundles)
@@ -167,13 +179,23 @@ class catalog_validator:
                     rhoai_version.startswith('3')
                     and numeric_ocp_version < self.MIN_OCP_VERSION_FOR_RHOAI_30
                 )
+                missing_from_bundle = (operator_name not in bundles)
 
-                if operator_name not in bundles and operator_name not in self.MISSING_BUNDLE_EXCEPTIONS:
-                    if not (is_3x_on_unsupported_ocp):
-                        if not self.rhods_operator(operator_name) >= self.rhods_operator(self.discontinuity_map[ocp_version]) and not self.rhods_operator(operator_name) <= self.rhods_operator(self.onboarding_map[ocp_version]):
-                            missing_bundles[pcc_file].append(operator_name)
-                        else:
-                            print(f'Ignoring since OCP {ocp_version} is not supported for {operator_name}')
+                if operator_name in bundles:
+                    continue
+
+                if operator_name in self.MISSING_BUNDLE_EXCEPTIONS:
+                    continue
+
+                if is_3x_on_unsupported_ocp:  # bypassing check for 3.0 for OCP < 4.19
+                    continue
+
+                if self.rhods_operator(operator_name) >= self.rhods_operator(self.discontinuity_map[ocp_version]) \
+                        or self.rhods_operator(operator_name) < self.rhods_operator(self.onboarding_map[ocp_version]):
+
+                    print(f'Ignoring since OCP {ocp_version} is not supported for {operator_name}')
+                else:
+                    missing_bundles[pcc_file].append(operator_name)
 
 
 

--- a/utils/validators/catalog_validator.py
+++ b/utils/validators/catalog_validator.py
@@ -68,6 +68,28 @@ class catalog_validator:
         def __lt__(self, other):
             return self._parsed_tuple < other._parsed_tuple
 
+        def __getitem__(self, key):
+            return self._parsed_tuple[key]
+
+        def __repr__(self):
+            return self.version
+
+        # given a list of versions, determine if this is the latest ea version for a given (major, minor, patch)
+        def is_latest_ea(self, versions_list):
+            latest = self._parsed_tuple
+            for item in versions_list:
+                try: 
+                    version = self.__class__(item) 
+                except ValueError:
+                    continue
+                else:
+                    if version[0:4] != latest[0:4]:
+                        continue
+                    if version[4:] > latest[4:]:
+                        latest = version
+            print(f"{latest} is the newest version in the vicinity of {self.version}")
+            return latest == self._parsed_tuple
+            
     def __init__(self, build_config_path, catalog_folder_path, shipped_rhoai_versions_path, operation, global_config_path):
         self.build_config_path = build_config_path
         self.catalog_folder_path = catalog_folder_path
@@ -134,9 +156,14 @@ class catalog_validator:
 
                 if self.rhods_operator(operator_name) >= self.rhods_operator(self.discontinuity_map[ocp_version]) \
                         or self.rhods_operator(operator_name) < self.rhods_operator(self.onboarding_map[ocp_version]):
-                    print(f'Ignoring since OCP {ocp_version} is not supported for {operator_name}')
-                else:
-                    missing_bundles[ocp_version].append(operator_name)
+                    print(f'Ignoring missing {operator_name} since OCP {ocp_version} is not supported for it')
+                    continue
+
+                if not self.rhods_operator(operator_name).is_latest_ea(bundles):
+                    print(f'Ignoring missing {operator_name} since it is expected to be overwritten by a newer EA release')
+                    continue
+
+                missing_bundles[ocp_version].append(operator_name)
 
         print('missing_bundles', missing_bundles)
         print('incorrect_3x_bundles', incorrect_3x_bundles)
@@ -193,7 +220,7 @@ class catalog_validator:
                 if self.rhods_operator(operator_name) >= self.rhods_operator(self.discontinuity_map[ocp_version]) \
                         or self.rhods_operator(operator_name) < self.rhods_operator(self.onboarding_map[ocp_version]):
 
-                    print(f'Ignoring since OCP {ocp_version} is not supported for {operator_name}')
+                    print(f'Ignoring missing {operator_name} since OCP {ocp_version} is not supported for it')
                 else:
                     missing_bundles[pcc_file].append(operator_name)
 


### PR DESCRIPTION
- **adding OCP specific pcc validaton along with 3.0 checks**
- **adding OCP specific pcc validaton along with 3.0 checks**
- **enhancing validation logic to exclude deprecated ocp versions**
- **enhancing validation logic to exclude deprecated ocp versions**
- **adding a check to overwrite an existing bundle**
- **adding stage promoter changes for 3.0**
- **adding stage promoter changes for 3.0**
- **adding stage promoter changes for 3.0**
- **adding debugging for operator processor**
- **disabling quay api filters due to 403 issue**
- **fixing catalog validation for 3.x bundles for OCP < 4.19**
- **fixing catalog validation for 3.x bundles for OCP < 4.19**
- **introducing onboarded from**
- **add capability for channel reset and prune  alpha channel to latest EA release**
- **use beta channel for EA drops**
- **Fix catalog validator to support EA versioning scheme**
- **Add discontinuity/onboarding map support to validate_catalogs**
- **add olm.bundle purge functionality**
- **feat: delete orphan bundles**
- **add bootstrap script to aid in testing changes to fbc-processor.py**
- **flatten pcc and catalog validation logic**
- **update catalog validator to properly handle catalog overwriting of older ea releases**
- **add bootstrap script to aid in validator troubleshooting**
- **fix: skip EA pruning when beta channel has no EA versions**
- **revert: restore EA version validation in prune_channel_to_latest_ea**
- **Update is_latest_ea logic**
- **add openshift version check before ea checks**
