### PR TITLE
Add per-OCP skip-bundles support to catalog validator

### DIFF
--- a/utils/validators/catalog_validator.py
+++ b/utils/validators/catalog_validator.py
@@ -111,6 +111,7 @@ class catalog_validator:
         global_ocp_versions = self.global_config['config']['supported-ocp-versions']
         self.discontinuity_map = {entry['version']: entry['discontinued-from'] if 'discontinued-from' in entry else 'rhods-operator.9.99.99' for entry in global_ocp_versions}
         self.onboarding_map = {entry['version']: entry['onboarded-since'] if 'onboarded-since' in entry else 'rhods-operator.0.0.0' for entry in global_ocp_versions}
+        self.skip_bundles_map = {entry['version']: entry['skip-bundles'] if 'skip-bundles' in entry else [] for entry in global_ocp_versions}
 
         self.shipped_rhoai_versions = open(self.shipped_rhoai_versions_path).readlines()
 
@@ -154,6 +155,10 @@ class catalog_validator:
                     continue
 
                 if operator_name in self.MISSING_BUNDLE_EXCEPTIONS:
+                    continue
+
+                if operator_name in self.skip_bundles_map[ocp_version]:
+                    print(f'{operator_name} is in skip-bundles list for OCP {ocp_version}. Skipping')
                     continue
 
                 if is_3x_on_unsupported_ocp:
@@ -218,6 +223,10 @@ class catalog_validator:
                     continue
 
                 if operator_name in self.MISSING_BUNDLE_EXCEPTIONS:
+                    continue
+
+                if operator_name in self.skip_bundles_map[ocp_version]:
+                    print(f'{operator_name} is in skip-bundles list for OCP {ocp_version}. Skipping')
                     continue
 
                 if is_3x_on_unsupported_ocp:  # bypassing check for 3.0 for OCP < 4.19


### PR DESCRIPTION
## Summary

- Adds `skip-bundles` per-OCP-version config in `config.yaml` to handle bundles that were
  never published to a specific OCP index (e.g. embargoed z-stream fixes)
- Updates `catalog_validator.py` to read and apply the `skip-bundles` list in both
  `validate_pcc` and `validate_catalogs` paths

## Context

OCP 4.21 was initially onboarded starting v3.3, but was later backdated to v2.25.0 via
`onboarded-since`. This caused the validator to expect all shipped bundles from 2.25.0
onwards in the v4.21 catalog, including `rhods-operator.3.2.1` — an embargoed fix that was
only published to the v4.19 and v4.20 Red Hat operator indexes.

The existing `onboarded-since` / `discontinued-from` model assumes a contiguous version
range per OCP version and has no way to express gaps. `skip-bundles` fills that gap.
