### PR TITLE
Add EA pruning check to validate_pcc()

### DIFF
--- a/utils/validators/catalog_validator.py
+++ b/utils/validators/catalog_validator.py
@@ -217,8 +217,6 @@ class catalog_validator:
                     rhoai_version.startswith('3')
                     and numeric_ocp_version < self.MIN_OCP_VERSION_FOR_RHOAI_30
                 )
-                missing_from_bundle = (operator_name not in bundles)
-
                 if operator_name in bundles:
                     continue
 
@@ -234,10 +232,14 @@ class catalog_validator:
 
                 if self.rhods_operator(operator_name) >= self.rhods_operator(self.discontinuity_map[ocp_version]) \
                         or self.rhods_operator(operator_name) < self.rhods_operator(self.onboarding_map[ocp_version]):
-
                     print(f'Ignoring missing {operator_name} since OCP {ocp_version} is not supported for it')
-                else:
-                    missing_bundles[pcc_file].append(operator_name)
+                    continue
+
+                if not self.rhods_operator(operator_name).is_latest_ea(bundles):
+                    print(f'Ignoring missing {operator_name} since it is expected to be overwritten by a newer EA release')
+                    continue
+
+                missing_bundles[pcc_file].append(operator_name)
 
 
 


### PR DESCRIPTION
## Summary
- `validate_pcc()` was missing the `is_latest_ea()` check that `validate_catalogs()` already has
- When a newer EA release (e.g. `3.4.0-ea.2`) replaces an older one (`3.4.0-ea.1`) in the production operator index, PCC regeneration drops the old bundle from catalogs while `shipped_rhoai_versions_granular.txt` still lists it
- This caused the rhoai-2.25 stage promoter to fail at the "Validate PCC Cache" step: https://github.com/red-hat-data-services/rhods-devops-infra/actions/runs/24813011188/job/72621596875

## What changed
- Added the same `is_latest_ea()` guard to `validate_pcc()` that already exists in `validate_catalogs()`
- Refactored the discontinuity check from if/else to early-continue for consistency with the rest of the method
- Removed unused `missing_from_bundle` variable

## Test plan
- [ ] Verify the rhoai-2.25 stage promoter passes the "Validate PCC Cache" step after this fix
- [ ] Confirm `validate_catalogs()` behavior is unchanged