### PR TITLE
fix: handle offboarded components in operator-processor

### DIFF
--- a/utils/operator-processor/operator-processor.py
+++ b/utils/operator-processor/operator-processor.py
@@ -90,8 +90,12 @@ class operator_processor:
         missing_git_labels = []
         for component, manifest_config in self.manifest_config_dict['map'].items():
             if 'ref_type' not in manifest_config or ('ref_type' in manifest_config and manifest_config['ref_type'] != 'branch'):
-                git_url = self.git_labels_meta['map'][component][self.GIT_URL_LABEL_KEY]
-                git_commit = self.git_labels_meta['map'][component][self.GIT_COMMIT_LABEL_KEY]
+                component_meta = self.git_labels_meta['map'].get(component)
+                if component_meta is None:
+                    print(f'WARNING: {component} in manifests-config but not in build metadata — possibly offboarded, skipping')
+                    continue
+                git_url = component_meta.get(self.GIT_URL_LABEL_KEY, '')
+                git_commit = component_meta.get(self.GIT_COMMIT_LABEL_KEY, '')
                 if git_url and git_commit:
                     manifest_config[self.GIT_URL_LABEL_KEY] = git_url
                     manifest_config[self.GIT_COMMIT_LABEL_KEY] = git_commit
@@ -307,5 +311,6 @@ if __name__ == '__main__':
     #                                manifest_config_path=manifest_config_path,
     #                              push_pipeline_yaml_path=push_pipeline_yaml_path, push_pipeline_operation=push_pipeline_operation)
     # processor.generate_latest_operands_map()
+
 
 


### PR DESCRIPTION
## Summary

- `update_manifest_config()` crashes with `KeyError` when a component is listed in `manifests-config.yaml` but no longer has build metadata (e.g. after offboarding)
- Changes direct `[]` access to `.get()` so missing components are skipped with a warning instead of crashing the pipeline
- Immediately unblocks pipelines broken by the odh-training-operator offboarding (RHOAIENG-79608)

## Root cause

The offboarding of `odh-training-operator` removed it from ODH-Build-Config (no more images), but `manifests-config.yaml` in the operator repo still references it. When `operator-processor.py` iterates `manifests-config.yaml` and looks up each component in the build metadata map, it crashes on the missing key.

## What changed

`utils/operator-processor/operator-processor.py` line 93: replaced `self.git_labels_meta['map'][component]` with `.get(component)` and a `None` guard that logs a warning and skips the component.

## Related

- [RHOAIENG-79608](https://issues.redhat.com/browse/RHOAIENG-79608) — Konflux Offboarding odh-training-operator
- [RHOAIENG-78350](https://issues.redhat.com/browse/RHOAIENG-78350) — Decommission Konflux Builds for Training Operator v1
- opendatahub-io/opendatahub-operator#3868 — removes `odh-training-operator` from `manifests-config.yaml` (root fix)