### PR TITLE
Auto-skip missing EA bundles in catalog validator

### DIFF
--- a/utils/validators/catalog_validator.py
+++ b/utils/validators/catalog_validator.py
@@ -170,8 +170,8 @@ class catalog_validator:
                     print(f'Ignoring missing {operator_name} since OCP {ocp_version} is not supported for it')
                     continue
 
-                if not self.rhods_operator(operator_name).is_latest_ea(bundles):
-                    print(f'Ignoring missing {operator_name} since it is expected to be overwritten by a newer EA release')
+                if '-ea.' in rhoai_version:
+                    print(f'Ignoring missing {operator_name} since EA bundles are branch-scoped and not expected in all catalogs')
                     continue
 
                 missing_bundles[ocp_version].append(operator_name)
@@ -236,8 +236,8 @@ class catalog_validator:
                     print(f'Ignoring missing {operator_name} since OCP {ocp_version} is not supported for it')
                     continue
 
-                if not self.rhods_operator(operator_name).is_latest_ea(bundles):
-                    print(f'Ignoring missing {operator_name} since it is expected to be overwritten by a newer EA release')
+                if '-ea.' in rhoai_version:
+                    print(f'Ignoring missing {operator_name} since EA bundles are branch-scoped and not expected in all catalogs')
                     continue
 
                 missing_bundles[pcc_file].append(operator_name)


### PR DESCRIPTION
## Problem

Every time a new EA release ships (3.4.0-ea.1, 3.5.0-ea.1, 3.5.0-ea.2, etc.), the catalog validator fails on older release branches because it expects the EA bundle in all catalogs. This requires manually adding skip-bundles entries to config/config.yaml for every EA release — a recurring manual step that blocks process-fbc-fragment and stage promoter workflows.

Recent examples:
- 3.5.0-ea.2 failing on rhoai-3.4 and rhoai-3.3: https://github.com/red-hat-data-services/RHOAI-Build-Config/actions/runs/29478579356
- Required manual skip-bundles PRs: #24626, #26809

## Root cause

The validator's `is_latest_ea()` check only skips OLDER EA versions (superseded by a newer EA). The NEWEST EA release is always expected in every catalog. But EA bundles are branch-scoped — `3.5.0-ea.2` only belongs on the `rhoai-3.5-ea.2` branch, not on `rhoai-3.4` or `rhoai-3.3`.

## Fix

Replace the `is_latest_ea()` check with a simple `'-ea.' in rhoai_version` check in both `validate_catalogs` and `validate_pcc`. Any missing EA bundle is automatically skipped since EA bundles are branch-scoped. GA bundles are still validated normally.

```python
# Before (fails for newest EA)
if not self.rhods_operator(operator_name).is_latest_ea(bundles):
    print(f'Ignoring missing {operator_name} since it is expected to be overwritten by a newer EA release')
    continue

# After (skips ALL missing EA bundles)
if '-ea.' in rhoai_version:
    print(f'Ignoring missing {operator_name} since EA bundles are branch-scoped and not expected in all catalogs')
    continue
```

## Test results

| Test | Scenario | Result |
|------|----------|--------|
| 1 | EA versions missing from catalogs | PASS — auto-skipped |
| 2 | EA version present in catalog | PASS — not flagged |
| 3 | GA version missing | FAIL — correctly detected |
| 4 | Multiple EA versions missing | PASS — all auto-skipped |
| 5 | GA missing from one OCP only | FAIL — correctly detected |
| 6 | validate-pcc with EA missing | PASS — auto-skipped |
| 7 | EA hotfix (3.5.0-ea.2.1) missing | PASS — auto-skipped |
| 8 | Only EA in shipped, no GA | PASS — no false failure |
| 9 | EA in catalog but not shipped | PASS — no false positive |

## Impact

Eliminates the need for manual skip-bundles entries for EA releases. No more manual config changes or PRs needed when new EA versions ship.

Fixes: RHOAIENG-74801